### PR TITLE
Fix initialization of read-only data

### DIFF
--- a/teensy4-rt/memory.x
+++ b/teensy4-rt/memory.x
@@ -69,15 +69,10 @@ SECTIONS
 
     __sitext = LOADADDR(.text);
 
-    .rodata :
-    {
-        *(.rodata .rodata.*);
-        . = ALIGN(4);
-    } > DTCM AT> FLASH
-
     .data :
     {
         __sdata = .;
+        *(.rodata .rodata.*);
         *(.data .data.*);
         . = ALIGN(16);
         __edata = .;
@@ -103,7 +98,7 @@ SECTIONS
     }
 
     /* The length of flash is required for the boot data */
-    __lflash = SIZEOF(.boot) + SIZEOF(.text) + SIZEOF(.rodata) + SIZEOF(.data);
+    __lflash = SIZEOF(.boot) + SIZEOF(.text) + SIZEOF(.data);
 
     /* The following are used to compute the FlexRAM banks for ITCM / DTCM */
     _itcm_block_count = (SIZEOF(.text) + 0x7FFE) >> 15;


### PR DESCRIPTION
We were never initializing read-only data. The
commit moves the section into the overall data
section. Alternatively, we could explicitly copy
over read-only data into the DTCM.

I tried keeping read-only data in FLASH, but the
teensy_cli_loader was yelling about a bad flash
section... Might re-evaluate this later. The
C implementation has the RO data in DTCM, so
we're up to parity with that.