### PR TITLE
Update PAC import tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 Cargo.lock
 /out
 /svd/imxrt1062/*
+
+# Let developers specify their own configs in non Teensy crates
+imxrt1062-fcb-gen/.cargo
+tools/.cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ script:
   - cargo build --verbose --all
   - cargo fmt --all -- --check
   # Run the tests in the FCB generation crate
-  - cd imxrt1062-fcb-gen && cargo test --target $(rustup show | grep "Default host" | cut -d' ' -f3) && cd ..
+  - cd imxrt1062-fcb-gen && cargo test --target $(rustc --verbose --version | grep host | cut -d' ' -f 2) && cd ..
+  # Run the import tool's tests
+  - cd tools && cd imxrt1062-fcb-gen && cargo test --target $(rustc --verbose --version | grep host | cut -d' ' -f 2) && cd ..
 cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ before_install:
   - rustup component add rustfmt
   - rustup target add thumbv7em-none-eabihf
 script:
+  - export RUST_HOST_TARGET="$(rustc --verbose --version | grep host | cut -d' ' -f2)" 
   - cargo build --verbose --all
   - cargo fmt --all -- --check
   # Run the tests in the FCB generation crate
-  - cd imxrt1062-fcb-gen && cargo test --target $(rustc --verbose --version | grep host | cut -d' ' -f 2) && cd ..
+  - cd imxrt1062-fcb-gen && cargo test --target $RUST_HOST_TARGET && cd ..
   # Run the import tool's tests
-  - cd tools && cd imxrt1062-fcb-gen && cargo test --target $(rustc --verbose --version | grep host | cut -d' ' -f 2) && cd ..
+  - cd tools && cargo test --target $RUST_HOST_TARGET && cd ..
 cache: cargo

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+toml = "0.5.5"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0.104"

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -1,6 +1,9 @@
 //! Allows us to auto-import a iMXRT1062 module
 //! from the svd2rust output into the imxrt1062-pac
 //! megacrate. It code-ifies some manual work.
+//! 
+//! We expect that this tool is run from the `tools`
+//! directory.
 //!
 //! This could probably use some better error handling...
 
@@ -12,16 +15,25 @@ use std::process;
 
 mod toml;
 
-static CARGO_TOML_DEPENDENCIES: &str = r#"vcell = "0.1.2"
+/// The name of the PAC crate into which we will
+/// put subcrates
+static OUTPUT_PAC_NAME: &str = "imxrt1062-pac";
+
+/// Add dependencies into the Cargo.toml of the new PAC subcrate
+/// identified by crate_path
+fn add_deps(crate_path: &Path) {
+    /// Dependencies that are added to each PAC subcrate
+    static CARGO_TOML_DEPENDENCIES: &str = r#"vcell = "0.1.2"
 "#;
 
-static CARGO_NO_TESTS_BENCH: &str = r#"
+    /// Additional directives to add into each PAC subcrate's
+    /// Cargo.toml
+    static CARGO_NO_TESTS_BENCH: &str = r#"
 [lib]
 bench = false
 test = false
 "#;
 
-fn add_deps(crate_path: &Path) {
     let mut cargo_toml = fs::OpenOptions::new()
         .append(true)
         .open(crate_path.join("Cargo.toml"))
@@ -36,7 +48,10 @@ fn add_deps(crate_path: &Path) {
         .expect("Failed to update Cargo.toml");
 }
 
-static LIB_PRELUDE: &str = r#"#![deny(warnings)]
+/// Migrate the `lib.rs` of the PAC subscrate, adding
+/// our necessary header to the top of the file.
+fn write_lib<R: Read>(crate_path: &Path, mut src: R) {
+    static LIB_PRELUDE: &str = r#"#![deny(warnings)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::all)]
 #![no_std]
@@ -44,8 +59,6 @@ static LIB_PRELUDE: &str = r#"#![deny(warnings)]
 include!("../../generic.rs");
 
 "#;
-
-fn write_lib<R: Read>(crate_path: &Path, mut src: R) {
     let mut crate_lib =
         fs::File::create(crate_path.join("src").join("lib.rs")).expect("Unable to crate lib.rs");
     crate_lib
@@ -54,6 +67,7 @@ fn write_lib<R: Read>(crate_path: &Path, mut src: R) {
     io::copy(&mut src, &mut crate_lib).unwrap();
 }
 
+/// Recursively copies the files from the provided iterator into the directory `crate_path`
 fn copy_contents<I: Iterator<Item = io::Result<fs::DirEntry>>>(crate_path: &Path, dir: I) {
     for entry in dir {
         let entry = entry.unwrap();
@@ -71,13 +85,16 @@ fn copy_contents<I: Iterator<Item = io::Result<fs::DirEntry>>>(crate_path: &Path
     }
 }
 
+/// We don't modify the PAC's `lib.rs` with the re-exports. To help
+/// our a user, suggest the new re-exports. They may copy and paste
+/// this into the file.
 fn suggest_reexports(crate_names: &[String]) {
     println!("imxrt1062-pac reexport additions...");
     for crate_name in crate_names {
         let crate_name = crate_name.replace("-", "_");
         // pub use imxrt1062_foo_bar as foo_bar
         let module = crate_name
-            .split("_")
+            .split('_')
             .skip(1)
             .map(String::from)
             .collect::<Vec<String>>()
@@ -103,6 +120,7 @@ fn update_workspace_toml(crate_names: &[String]) {
     fs::write(WORKSPACE_CARGO_TOML, new_toml).unwrap();
 }
 
+/// Add the new dependencies into the top-level PAC's Cargo.toml
 fn update_pac_dependencies(output_pac: &Path, crate_names: &[String]) {
     let output_pac_toml = output_pac.join("Cargo.toml");
     let mut krate: toml::Krate = {
@@ -115,8 +133,6 @@ fn update_pac_dependencies(output_pac: &Path, crate_names: &[String]) {
     let new_toml = ::toml::ser::to_string_pretty(&krate).unwrap();
     fs::write(&output_pac_toml, new_toml).unwrap();
 }
-
-static OUTPUT_PAC_NAME: &str = "imxrt1062-pac";
 
 fn main() {
     let output_pac: PathBuf = PathBuf::from("../").join(OUTPUT_PAC_NAME);
@@ -137,10 +153,9 @@ fn main() {
                 .join("src")
                 .join(format!("{}.rs", module_name)),
         )
-        .expect(&format!("Unable to find main module for {}", module_name));
-        let peripheral_dir_src = fs::read_dir(svd_crate_path.join("src").join(module_name)).expect(
-            &format!("Unable to find module directory for {}", module_name),
-        );
+        .unwrap_or_else(|_| panic!("Unable to find main module for {}", module_name));
+        let peripheral_dir_src = fs::read_dir(svd_crate_path.join("src").join(module_name))
+            .unwrap_or_else(|_| panic!("Unable to find module directory for {}", module_name));
 
         let crate_name = format!("imxrt1062-{}", module_name.replace("_", "-"));
         let peripheral_crate_path = output_pac.join(crate_name.clone());
@@ -160,10 +175,7 @@ fn main() {
                 "none",
             ])
             .output()
-            .expect(&format!(
-                "Cannot create peripheral crate for '{}'",
-                module_name
-            ));
+            .unwrap_or_else(|_| panic!("Cannot create peripheral crate for '{}'", module_name));
 
         add_deps(&peripheral_crate_path);
         write_lib(&peripheral_crate_path, peripheral_module_src);

--- a/tools/src/toml.rs
+++ b/tools/src/toml.rs
@@ -1,0 +1,134 @@
+//! Support for modifying Cargo.toml files
+
+pub use krate::Krate;
+pub use workspace::Workspace;
+
+/// Support for Cargo.toml workspaces
+mod workspace {
+    use std::path::Path;
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct Table {
+        members: Vec<String>,
+        exclude: Vec<String>,
+    }
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    pub struct Workspace {
+        workspace: Table,
+    }
+
+    impl Workspace {
+        /// Add a new member to the workspace, then sort the collection of
+        /// members.
+        pub fn add_member<P: AsRef<Path>>(&mut self, member: P) {
+            let member = member.as_ref().display().to_string();
+            if self.workspace.members.contains(&member) {
+                return;
+            }
+            self.workspace.members.push(member);
+            self.workspace.members.sort_unstable();
+        }
+    }
+}
+
+/// Support for Cargo.toml crate specs
+mod krate {
+    use std::collections::BTreeMap;
+    use std::path::Path;
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct WithPath {
+        path: String,
+    }
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(untagged)]
+    enum Dependency {
+        JustVersion(String),
+        WithPath(WithPath),
+    }
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    pub struct Krate {
+        /// Catch-all for the rest of the file
+        #[serde(flatten)]
+        _rest: toml::value::Value,
+        // https://github.com/alexcrichton/toml-rs/issues/142#issuecomment-279009115
+        #[serde(serialize_with = "toml::ser::tables_last")]
+        dependencies: BTreeMap<String, Dependency>,
+    }
+
+    impl Krate {
+        pub fn add_dependency<P: AsRef<Path>>(&mut self, name: &str, path: P) {
+            self.dependencies.insert(
+                name.to_string(),
+                Dependency::WithPath(WithPath {
+                    path: path.as_ref().display().to_string(),
+                }),
+            );
+        }
+    }
+}
+
+//
+// TODO these tests are brittle, relying on the
+// implementation details of serde & toml. We should
+// fix this to ensure that there are matching substrings...
+//
+
+#[cfg(test)]
+mod tests {
+
+    use super::Krate;
+    use super::Workspace;
+
+    #[test]
+    fn add_workspace_member() {
+        let ws_str = r#"[workspace]
+members = ["foo", "bar", "baz"]
+exclude = ["ignore"]
+"#;
+        let mut ws: Workspace = toml::de::from_str(ws_str).unwrap();
+        ws.add_member("abc");
+        let updated_ws = toml::ser::to_string(&ws).unwrap();
+        assert_eq!(
+            updated_ws,
+            r#"[workspace]
+members = ["abc", "bar", "baz", "foo"]
+exclude = ["ignore"]
+"#
+        )
+    }
+
+    #[test]
+    fn add_crate_dependency() {
+        let crate_str = r#"[package]
+name = "crate_name"
+version = "1.2.3"
+
+[dependencies]
+foo = "1.23"
+bar = { path = "path/to/bar" }
+"#;
+        let mut krate: Krate = toml::de::from_str(crate_str).unwrap();
+        krate.add_dependency("a_new_dep", "path/to/new/dep");
+        let updated_crate = toml::ser::to_string(&krate).unwrap();
+        assert_eq!(
+            updated_crate,
+            r#"[package]
+name = "crate_name"
+version = "1.2.3"
+
+[dependencies]
+foo = "1.23"
+
+[dependencies.a_new_dep]
+path = "path/to/new/dep"
+
+[dependencies.bar]
+path = "path/to/bar"
+"#
+        );
+    }
+}


### PR DESCRIPTION
The PR updates the PAC import tool. The tool will now directly update the workspace `Cargo.toml` and the PAC `Cargo.toml` with the newly-imported PAC subcrates. We add some additional docs to the tool.