### PR TITLE
Add hardware-test.bat for Windows

### DIFF
--- a/hardware-test.bat
+++ b/hardware-test.bat
@@ -1,0 +1,28 @@
+@echo off
+
+SET scriptbuildflag=--release
+SET scriptbin=%1
+IF NOT DEFINED scriptbin (goto :needbin)
+IF "%2"=="--debug" (SET "scriptbuildflag=")
+IF NOT DEFINED scriptbuildflag (
+	SET scriptbuildmode=debug
+) ELSE (
+	SET scriptbuildmode=release
+)
+cargo build %scriptbuildflag% -p teensy4-examples --bin %scriptbin% || goto :error
+rmdir /S /Q out || goto :error
+mkdir out || goto :error
+copy "target\thumbv7em-none-eabihf\%scriptbuildmode%\%scriptbin%" "out\%scriptbin%" || goto :error
+arm-none-eabi-objdump -d -S -C "out\%scriptbin%" > "out\%scriptbin%.lst" || goto :error
+arm-none-eabi-objdump -t -C "out\%scriptbin%" > "out\%scriptbin%.sym" || goto :error
+arm-none-eabi-objcopy -O ihex -R .eeprom "out\%scriptbin%" "out\%scriptbin%.hex" || goto :error
+echo Now use Teensy Loader to load out\%scriptbin%.hex onto the Teensy 4.
+goto :EOF
+
+:needbin
+echo Need an example to build, such as 'led'.
+exit /b 160
+
+:error
+echo Failed with error code %errorlevel%.
+exit /b %errorlevel%


### PR DESCRIPTION
Adds a mostly-equivalent Windows batch file version of hardware-test.sh.

It's been years since I wrote a batch file so I can't guarantee this is fully properly written, but it does work on the examples, in both release and debug modes, and properly fails fast on errors as far as I can test. It's fairly ugly.

I can't build `teensy_loader_cli` through MinGW or find a Teensy 4-capable Windows build, so that functionality is missing. This script also doesn't check that arg 2 is either `--debug` or empty.

Requires the [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) to be installed and in the path, which is a non-default installation option.