### PR TITLE
Add support for UART RX, PIT timer interrupts

### DIFF
--- a/imxrt1062-hal/src/ccm.rs
+++ b/imxrt1062-hal/src/ccm.rs
@@ -316,6 +316,12 @@ pub fn ticks<R: TicksRepr>(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Frequency(u32);
 
+impl From<Frequency> for core::time::Duration {
+    fn from(hz: Frequency) -> core::time::Duration {
+        core::time::Duration::from_nanos((1_000_000_000u32 / hz.0).into())
+    }
+}
+
 impl From<Frequency> for Ticks<u32> {
     fn from(hz: Frequency) -> Ticks<u32> {
         Ticks(hz.0)

--- a/imxrt1062-hal/src/pit.rs
+++ b/imxrt1062-hal/src/pit.rs
@@ -101,10 +101,12 @@ impl<Chan: channel::Channel> PIT<Chan> {
         }
     }
 
-    fn disabled<F: FnMut()>(&self, mut act: F) {
+    fn disabled<F: FnMut(&Self) -> R, R>(&self, mut act: F) -> R {
+        let enabled = self.timer.tctrl.read().ten().bit_is_set();
         self.timer.tctrl.modify(|_, w| w.ten().clear_bit());
-        act();
-        self.timer.tctrl.modify(|_, w| w.ten().set_bit());
+        let res = act(self);
+        self.timer.tctrl.modify(|_, w| w.ten().bit(enabled));
+        res
     }
 
     fn ldval(&self, val: u32) {
@@ -116,22 +118,71 @@ impl<Chan: channel::Channel> PIT<Chan> {
         self.timer.tflg.read().tif().bit_is_set()
     }
 
-    fn clear_tif(&mut self) {
+    fn clear_tif(&self) {
         // W1C
         self.timer.tflg.write(|w| w.tif().set_bit());
     }
 
+    /// Returns the period of the clock ticks. This is the inverse
+    /// of the clock frequency
+    pub fn clock_period(&self) -> core::time::Duration {
+        (self.clock_hz / self.divider).into()
+    }
+
+    /// Measure the execution duration of `act` with this timer. Returns the duration
+    /// of the action, or `None` if the timer expired before the action completed.
+    ///
+    /// `time` will measure the difference of counts in a 32 bit register. The counter
+    /// changes every clock period. The clock accuracy is based on our ability to round
+    /// integers. Consider choosing the input clock frequency and prescalars to define
+    /// a clock that can accurately measure your workloads.
+    ///
+    /// The method will disable any interrupts that this timer has enabled. It will also
+    /// reset the timer to execute this measurement.
+    ///
+    /// If you need a 64 bit timer, use the `chain` function to combine timer 0 and
+    /// timer 1. The two can crate the 'lifetime' timer, which is capable of measuring
+    /// larger intervals.
+    pub fn time<F: FnMut() -> R, R>(&mut self, mut act: F) -> (R, Option<core::time::Duration>) {
+        const STARTING_LDVAL: u32 = u32::max_value();
+        self.with_interrupts_disabled(|this| {
+            this.disabled(|this| {
+                this.clear_tif();
+                this.ldval(STARTING_LDVAL);
+                self.timer.tctrl.modify(|_, w| w.ten().set_bit());
+                let res = act();
+                if this.tif() {
+                    // Action took too long and the timer expired
+                    (res, None)
+                } else {
+                    let counter = this.timer.cval.read().tvl().bits();
+                    let ticks = STARTING_LDVAL - counter;
+                    let clock_period: core::time::Duration = (this.clock_hz / this.divider).into();
+                    (res, Some(ticks * clock_period))
+                }
+            })
+        })
+    }
+
     /// Enable the timer to trigger an interrupt when the timer expires
     pub fn set_interrupt_enable(&mut self, interrupt: bool) {
-        self.disabled(|| {
-            self.timer.tctrl.modify(|_, w| w.tie().bit(interrupt));
-        });
+        self.timer.tctrl.modify(|_, w| w.tie().bit(interrupt));
     }
 
     /// Returns `true` if the timer will trigger an interrupt when
     /// it expires.
     pub fn interrupt_enable(&self) -> bool {
         self.timer.tctrl.read().tie().bit_is_set()
+    }
+
+    fn with_interrupts_disabled<F: FnMut(&Self) -> R, R>(&self, mut act: F) -> R {
+        let interrupt_enabled = self.interrupt_enable();
+        self.timer.tctrl.modify(|_, w| w.tie().clear_bit());
+        let res = act(self);
+        self.timer
+            .tctrl
+            .modify(|_, w| w.tie().bit(interrupt_enabled));
+        res
     }
 }
 
@@ -147,9 +198,10 @@ impl<Chan: channel::Channel> CountDown for PIT<Chan> {
             // Ratio of freq / div was zero, or divider was zero
             Err(TicksError::DivideByZero) => Ticks(0),
         };
-        self.disabled(|| {
-            self.ldval(ticks.0);
-        });
+        self.clear_tif();
+        self.timer.tctrl.modify(|_, w| w.ten().clear_bit());
+        self.ldval(ticks.0);
+        self.timer.tctrl.modify(|_, w| w.ten().set_bit());
     }
 
     fn wait(&mut self) -> nb::Result<(), void::Void> {
@@ -217,21 +269,74 @@ where
             // Ratio of freq / div was zero, or divider was zero
             Err(TicksError::DivideByZero) => Ticks(0),
         };
-        self.lower.disabled(|| {
-            self.upper.disabled(|| {
-                self.upper.timer.tctrl.modify(|_, w| w.chn().set_bit());
-                self.upper.ldval((ticks.0 >> 32) as u32);
-                self.lower.ldval((ticks.0 & 0xFFFF_FFFF) as u32)
-            })
-        });
+        self.lower.timer.tctrl.modify(|_, w| w.ten().clear_bit());
+        self.upper.timer.tctrl.modify(|_, w| w.ten().clear_bit());
+
+        self.upper.clear_tif();
+        self.upper.timer.tctrl.modify(|_, w| w.chn().set_bit());
+        self.upper.ldval((ticks.0 >> 32) as u32);
+        self.lower.ldval((ticks.0 & 0xFFFF_FFFF) as u32);
+
+        self.lower.timer.tctrl.modify(|_, w| w.ten().set_bit());
+        self.upper.timer.tctrl.modify(|_, w| w.ten().set_bit());
     }
 
     fn wait(&mut self) -> nb::Result<(), void::Void> {
         if self.upper.tif() {
-            self.upper.clear_tif();
             Ok(())
         } else {
             Err(nb::Error::WouldBlock)
         }
+    }
+}
+
+/// The lifetime timer is PIT0 chained to PIT1.
+/// It allows us to time over 64 bits with no
+/// carry.
+impl ChainedPIT<channel::_0, channel::_1> {
+    /// Time the execution duration of `act`. Returns the time it took to run `act`,
+    /// or `None` if the timer expired.
+    ///
+    /// See the notes on `PIT::time`. Unlike `PIT::time`, this `time` method uses
+    /// a 64 bit register, which can help measure larger intervals. As with `PIT::time`,
+    /// this function will temporarily disable interrupts and reset any currently-running
+    /// timer.
+    ///
+    /// This method is only available when chaining timer 0 to timer 1.
+    pub fn time<F: Fn() -> R, R>(&mut self, act: F) -> (R, Option<core::time::Duration>) {
+        const STARTING_LDVAL: u32 = u32::max_value();
+        self.upper.with_interrupts_disabled(|upper| {
+            self.lower.disabled(|lower| {
+                upper.disabled(|upper| {
+                    upper.clear_tif();
+                    upper.ldval(STARTING_LDVAL);
+                    lower.ldval(STARTING_LDVAL);
+
+                    upper.timer.tctrl.modify(|_, w| w.chn().set_bit());
+                    upper.timer.tctrl.modify(|_, w| w.ten().set_bit());
+                    lower.timer.tctrl.modify(|_, w| w.ten().set_bit());
+
+                    let res = act();
+
+                    if upper.tif() {
+                        (res, None)
+                    } else {
+                        let pit = unsafe { &*pac::PIT::ptr() };
+
+                        let lifetime: u64 = (pit.ltmr64h.read().bits() as u64) << 32;
+                        let lifetime = lifetime | (pit.ltmr64l.read().bits() as u64);
+                        let ticks = u64::max_value() - lifetime;
+                        // Betting that this isn't lossy...
+                        let clock_period: u64 =
+                            core::time::Duration::from(upper.clock_hz / upper.divider).as_nanos()
+                                as u64;
+                        (
+                            res,
+                            Some(core::time::Duration::from_nanos(ticks * clock_period)),
+                        )
+                    }
+                })
+            })
+        })
     }
 }

--- a/imxrt1062-hal/src/uart.rs
+++ b/imxrt1062-hal/src/uart.rs
@@ -373,7 +373,7 @@ where
             if let Some(watermark) = watermark {
                 let rx_fifo_size = if this.reg.fifo.read().rxfe().bit_is_set() && watermark > 0 {
                     // Use the FIFO watermark to define interrupt frequency.
-                    let max_size = this.reg.param.read().rxfifo().bits() << 1;
+                    let max_size = 1 << this.reg.param.read().rxfifo().bits();
                     let fifo_size = max_size.min(watermark);
                     this.reg.water.modify(|_, w| unsafe {
                         // Safety: see justification in set_tx_fifo

--- a/imxrt1062-hal/src/uart.rs
+++ b/imxrt1062-hal/src/uart.rs
@@ -355,6 +355,43 @@ where
                 .set_bit()
         });
     }
+
+    /// Enable the receiver interrupt associated with this UART
+    ///
+    /// The interrupt will trigger when there are at least `watermark` number of
+    /// bytes in the RX FIFO. Returns the maximum-allowable watermark level that
+    /// was set in hardware. A watermark of `Some(0)` means that we should interrupt
+    /// as soon as a byte is read.
+    ///
+    /// If the watermark is greater than 0, ensure that you call `set_rx_fifo` before this
+    /// method. Otherwise, the return will be 0 despite the supplied watermark.
+    ///
+    /// Disable receiver interrupt by setting `watermark` to `None`. The return is always 0
+    /// when disabling the receiver interrupt.
+    pub fn set_receiver_interrupt(&mut self, watermark: Option<u8>) -> u8 {
+        self.while_disabled(|this| {
+            if let Some(watermark) = watermark {
+                let rx_fifo_size = if this.reg.fifo.read().rxfe().bit_is_set() && watermark > 0 {
+                    // Use the FIFO watermark to define interrupt frequency.
+                    let max_size = this.reg.param.read().rxfifo().bits() << 1;
+                    let fifo_size = max_size.min(watermark);
+                    this.reg.water.modify(|_, w| unsafe {
+                        // Safety: see justification in set_tx_fifo
+                        w.rxwater().bits(fifo_size)
+                    });
+                    fifo_size
+                } else {
+                    // User has not enable the RX FIFO, or the watermark is zero.
+                    0
+                };
+                this.reg.ctrl.modify(|_, w| w.rie().set_bit());
+                rx_fifo_size
+            } else {
+                this.reg.ctrl.modify(|_, w| w.rie().clear_bit());
+                0
+            }
+        })
+    }
 }
 
 use embedded_hal::serial;

--- a/teensy4-examples/Cargo.toml
+++ b/teensy4-examples/Cargo.toml
@@ -50,6 +50,12 @@ test = false
 bench = false
 
 [[bin]]
+name = "timer"
+path = "src/timer.rs"
+test = false
+bench = false
+
+[[bin]]
 name = "uart"
 path = "src/uart.rs"
 test = false

--- a/teensy4-examples/src/timer.rs
+++ b/teensy4-examples/src/timer.rs
@@ -1,0 +1,54 @@
+//! Demonstrates how to use a periodic interrupt
+//! timer (PIT) to measure a duration.
+
+//! Enables a PIT timer to test interrupts
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use bsp::hal::pit;
+use bsp::rt::entry;
+use embedded_hal::timer::CountDown;
+use teensy4_bsp as bsp;
+
+#[entry]
+fn main() -> ! {
+    let mut periphs = bsp::Peripherals::take().unwrap();
+    bsp::delay(25);
+    periphs.log.init(Default::default());
+
+    let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
+        bsp::hal::ccm::PLL1::ARM_HZ,
+        &mut periphs.ccm.handle,
+        &mut periphs.dcdc,
+    );
+
+    let cfg = periphs.ccm.perclk.configure(
+        &mut periphs.ccm.handle,
+        bsp::hal::ccm::perclk::PODF::DIVIDE_3,
+        bsp::hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+    );
+
+    let (timer0, timer1, mut timer2, mut timer3) = periphs.pit.clock(cfg);
+    let mut timer = pit::chain(timer0, timer1);
+    loop {
+        let (_, period) = timer.time(|| {
+            bsp::delay(7_000);
+        });
+        match period {
+            Some(period) => log::info!("Timed a {:?} long event with the lifetime timer", period),
+            None => log::warn!("Lifetime timer expired!"),
+        };
+
+        timer3.start(core::time::Duration::from_micros(217));
+        let (_, period) = timer2.time(|| {
+            nb::block!(timer3.wait()).unwrap();
+        });
+        match period {
+            Some(period) => log::info!("Timed a {:?} long event with timer 2", period),
+            None => log::warn!("Timer 2 expired!"),
+        }
+    }
+}

--- a/teensy4-examples/src/timer.rs
+++ b/teensy4-examples/src/timer.rs
@@ -10,6 +10,7 @@ extern crate panic_halt;
 
 use bsp::hal::pit;
 use bsp::rt::entry;
+use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
 use teensy4_bsp as bsp;
 
@@ -33,22 +34,31 @@ fn main() -> ! {
 
     let (timer0, timer1, mut timer2, mut timer3) = periphs.pit.clock(cfg);
     let mut timer = pit::chain(timer0, timer1);
+    let mut led = periphs.led;
     loop {
         let (_, period) = timer.time(|| {
-            bsp::delay(7_000);
+            led.set_high().unwrap();
+            bsp::delay(500);
+            led.set_low().unwrap();
         });
         match period {
             Some(period) => log::info!("Timed a {:?} long event with the lifetime timer", period),
             None => log::warn!("Lifetime timer expired!"),
         };
 
-        timer3.start(core::time::Duration::from_micros(217));
+        bsp::delay(100);
+
+        timer3.start(core::time::Duration::from_micros(200));
         let (_, period) = timer2.time(|| {
+            led.set_high().unwrap();
             nb::block!(timer3.wait()).unwrap();
+            led.set_low().unwrap();
         });
         match period {
             Some(period) => log::info!("Timed a {:?} long event with timer 2", period),
             None => log::warn!("Timer 2 expired!"),
         }
+
+        bsp::delay(100);
     }
 }


### PR DESCRIPTION
The PR allows users to configure PIT and UART RX interrupts. A user can enable the PIT interrupt to trigger when the timer expires. A user can identify which timer expired by checking `wait()`, which returns `Ok(())` if that timer was the cause of the interrupt. We update the PIT example to make use of interrupts.

Since the UART RX hardware buffer is small, a UART RX interrupt may help users implement their own buffering. Users may now configure UART RX interrupts with a configurable watermark.

The PR also provides support for timing intervals with the PIT timers. See the new example, `timer.rs`, for a demonstration of the API.