### PR TITLE
Add reading of USB serial messages from host

### DIFF
--- a/teensy4-bsp/src/lib.rs
+++ b/teensy4-bsp/src/lib.rs
@@ -104,7 +104,7 @@
 // Need to reference this so that it doesn't get stripped out
 extern crate teensy4_fcb;
 
-pub mod log;
+pub mod usb;
 
 pub use hal::pac::interrupt;
 pub use imxrt1062_hal as hal;
@@ -171,8 +171,8 @@ pub struct Peripherals {
     pub ccm: hal::ccm::CCM,
     /// PIT timers (forwarded from the HAL)
     pub pit: hal::pit::UnclockedPIT,
-    /// The USB logger
-    pub log: log::Logging,
+    /// The USB logger and serial reader
+    pub usb: usb::USB,
     /// DCDC converters
     pub dcdc: hal::dcdc::DCDC,
     /// PWM2 controller
@@ -214,7 +214,7 @@ impl Peripherals {
             },
             ccm: p.ccm,
             pit: p.pit,
-            log: log::Logging::new(),
+            usb: usb::USB::new(),
             dcdc: p.dcdc,
             pwm2: p.pwm2,
             pins: Pins {

--- a/teensy4-bsp/teensy4-usb-sys/src/lib.rs
+++ b/teensy4-bsp/teensy4-usb-sys/src/lib.rs
@@ -55,14 +55,22 @@ extern "C" {
     /// The implementation never appears to return a negative value,
     /// despite returning an integer.
     fn usb_serial_write(buffer: *const u8, size: u32) -> i32;
+    /// Read from the USB serila endpoint
+    fn usb_serial_read(buffer: *mut u8, size: u32) -> i32;
 }
 
 /// Writes the buffer of data to the USB host
 ///
 /// TODO error handling, return the number of bytes written, etc.
 pub fn serial_write<B: AsRef<[u8]>>(buffer: &B) {
+    let buffer = buffer.as_ref();
     unsafe {
-        let buffer = buffer.as_ref();
         usb_serial_write(buffer.as_ptr(), buffer.len() as u32);
     }
+}
+
+/// Reads a buffer of data from the USB serial endpoint
+pub fn serial_read<B: AsMut<[u8]>>(mut buffer: B) -> usize {
+    let buffer = buffer.as_mut();
+    unsafe { usb_serial_read(buffer.as_mut_ptr(), buffer.len() as u32) as usize }
 }

--- a/teensy4-examples/src/i2c.rs
+++ b/teensy4-examples/src/i2c.rs
@@ -26,7 +26,7 @@ where
 #[bsp::rt::entry]
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
-    peripherals.log.init(Default::default());
+    peripherals.usb.init(Default::default());
     bsp::delay(5000);
 
     log::info!("Enabling I2C clocks...");

--- a/teensy4-examples/src/pwm.rs
+++ b/teensy4-examples/src/pwm.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
     // Prepare all the BSP peripherals
     let mut p = bsp::Peripherals::take().unwrap();
     // Initialize the logging, so we can use it in the PWM loop below
-    p.log.init(Default::default());
+    p.usb.init(Default::default());
     // Delay is only to let a user set-up their USB serial connection...
     bsp::delay(5000);
     // Set the core and IPG clock. The IPG clock frequency drives the PWM (sub)modules

--- a/teensy4-examples/src/timer.rs
+++ b/teensy4-examples/src/timer.rs
@@ -18,7 +18,7 @@ use teensy4_bsp as bsp;
 fn main() -> ! {
     let mut periphs = bsp::Peripherals::take().unwrap();
     bsp::delay(25);
-    periphs.log.init(Default::default());
+    periphs.usb.init(Default::default());
 
     let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
         bsp::hal::ccm::PLL1::ARM_HZ,

--- a/teensy4-examples/src/uart.rs
+++ b/teensy4-examples/src/uart.rs
@@ -72,7 +72,7 @@ fn read<R: Read<u8>>(uart: &mut R, bytes: &mut [u8]) -> Result<(), R::Error> {
 #[entry]
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
-    peripherals.log.init(Default::default());
+    peripherals.usb.init(Default::default());
     bsp::delay(5_000);
     let uarts = peripherals.uart.clock(
         &mut peripherals.ccm.handle,

--- a/teensy4-examples/src/usb.rs
+++ b/teensy4-examples/src/usb.rs
@@ -1,4 +1,5 @@
-//! Demonstrates our ability to log / print over USB.
+//! Demonstrates our ability to log over USB, and read
+//! USB serial messages from a USB host.
 
 #![no_std]
 #![no_main]
@@ -13,14 +14,32 @@ use embedded_hal::digital::v2::ToggleableOutputPin;
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
-    // Initialize logging with the default settings
-    p.log.init(Default::default());
+    // Initialize the USB stack with the default logging settings
+    let mut usb_reader = p.usb.init(bsp::usb::LoggingConfig {
+        filters: &[("usb", None)],
+        ..Default::default()
+    });
     bsp::delay(2000);
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
     let mut led = p.led;
+    let mut buffer = [0; 256];
     loop {
+        let bytes_read = usb_reader.read(&mut buffer);
+        if bytes_read > 0 {
+            let bytes = &buffer[..bytes_read];
+            match core::str::from_utf8(bytes) {
+                Ok(msg) => log::info!("Received message: {} ({:?})", msg, bytes),
+                Err(e) => log::warn!(
+                    "Read {} bytes, but could not interpret message {:?}: {:?}",
+                    bytes_read,
+                    bytes,
+                    e
+                ),
+            }
+        }
+
         log::error!("Something terrible happened!");
         log::warn!("Something happened, but we fixed it");
         log::info!("It's 31'C outside");


### PR DESCRIPTION
We change the BSP's log module to the 'usb' module. When you initialize
the USB module, you enable the logging back-end, and you get access
to a usb::Reader type. The Reader may be used to read USB serial
messages from the serial endpoint.

This represents a breaking change for anyone using these crates from
the git repository. The `log` member of the `bsp::Peripherals` struct
is now called `usb`. The logging config struct, called
`bsp::log::Config`, is now `bsp::usb::LoggingConfig`. See the diff for
examples of how one might migrate their libraies and tools based on
these changes.

I'm not maintaining a changelog yet, since these crates aren't on
crates.io. Once they're on crates.io, these types of changes will
be called out and enforced by crate version numbers.