### PR TITLE
Provide more PWM pins and modules, fix get_duty

### DIFF
--- a/imxrt1062-hal/src/iomuxc.rs
+++ b/imxrt1062-hal/src/iomuxc.rs
@@ -74,6 +74,11 @@ pub struct IOMUXC {
     //
     // GPIO_EMC
     //
+    pub gpio_emc_04: gpio::GPIO_EMC_04<Alt5>,
+    pub gpio_emc_05: gpio::GPIO_EMC_05<Alt5>,
+    pub gpio_emc_06: gpio::GPIO_EMC_06<Alt5>,
+    pub gpio_emc_07: gpio::GPIO_EMC_07<Alt5>,
+    pub gpio_emc_08: gpio::GPIO_EMC_08<Alt5>,
     pub gpio_emc_31: gpio::GPIO_EMC_31<Alt5>,
     pub gpio_emc_32: gpio::GPIO_EMC_32<Alt5>,
     //
@@ -122,6 +127,11 @@ impl IOMUXC {
             //
             // GPIO_EMC
             //
+            gpio_emc_04: gpio::GPIO_EMC_04::new(&iomuxc),
+            gpio_emc_05: gpio::GPIO_EMC_05::new(&iomuxc),
+            gpio_emc_06: gpio::GPIO_EMC_06::new(&iomuxc),
+            gpio_emc_07: gpio::GPIO_EMC_07::new(&iomuxc),
+            gpio_emc_08: gpio::GPIO_EMC_08::new(&iomuxc),
             gpio_emc_31: gpio::GPIO_EMC_31::new(&iomuxc),
             gpio_emc_32: gpio::GPIO_EMC_32::new(&iomuxc),
 

--- a/imxrt1062-hal/src/iomuxc/gpio/emc.rs
+++ b/imxrt1062-hal/src/iomuxc/gpio/emc.rs
@@ -1,4 +1,44 @@
 pad!(
+    GPIO_EMC_04,
+    sw_mux_ctl_pad_gpio_emc_04,
+    sw_pad_ctl_pad_gpio_emc_04,
+    SW_PAD_CTL_PAD_GPIO_EMC_04,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);
+
+pad!(
+    GPIO_EMC_05,
+    sw_mux_ctl_pad_gpio_emc_05,
+    sw_pad_ctl_pad_gpio_emc_05,
+    SW_PAD_CTL_PAD_GPIO_EMC_05,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);
+
+pad!(
+    GPIO_EMC_06,
+    sw_mux_ctl_pad_gpio_emc_06,
+    sw_pad_ctl_pad_gpio_emc_06,
+    SW_PAD_CTL_PAD_GPIO_EMC_06,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);
+
+pad!(
+    GPIO_EMC_07,
+    sw_mux_ctl_pad_gpio_emc_07,
+    sw_pad_ctl_pad_gpio_emc_07,
+    SW_PAD_CTL_PAD_GPIO_EMC_07,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);
+
+pad!(
+    GPIO_EMC_08,
+    sw_mux_ctl_pad_gpio_emc_08,
+    sw_pad_ctl_pad_gpio_emc_08,
+    SW_PAD_CTL_PAD_GPIO_EMC_08,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);
+
+pad!(
     GPIO_EMC_31,
     sw_mux_ctl_pad_gpio_emc_31,
     sw_pad_ctl_pad_gpio_emc_31,

--- a/imxrt1062-hal/src/iomuxc/pwm.rs
+++ b/imxrt1062-hal/src/iomuxc/pwm.rs
@@ -20,26 +20,15 @@ pub mod output {
 /// Type tags that designate a PWM module
 pub mod module {
     /// Describes a PWM pin's associated module
-    pub trait Module {
-        /// Numeric value (1, 2, 3, 4) representing the module
-        const IDX: usize;
-    }
+    pub trait Module {}
     pub struct _1;
-    impl Module for _1 {
-        const IDX: usize = 1;
-    }
+    impl Module for _1 {}
     pub struct _2;
-    impl Module for _2 {
-        const IDX: usize = 2;
-    }
+    impl Module for _2 {}
     pub struct _3;
-    impl Module for _3 {
-        const IDX: usize = 3;
-    }
+    impl Module for _3 {}
     pub struct _4;
-    impl Module for _4 {
-        const IDX: usize = 4;
-    }
+    impl Module for _4 {}
 }
 
 /// Type tags for PWM submodules

--- a/imxrt1062-hal/src/iomuxc/pwm.rs
+++ b/imxrt1062-hal/src/iomuxc/pwm.rs
@@ -1,8 +1,11 @@
 //! PWM pin labels
 
 use crate::iomuxc::{
-    gpio::{GPIO_B0_10, GPIO_B0_11},
-    Alt2,
+    gpio::{
+        GPIO_B0_10, GPIO_B0_11, GPIO_B1_00, GPIO_B1_01, GPIO_EMC_04, GPIO_EMC_05, GPIO_EMC_06,
+        GPIO_EMC_08,
+    },
+    Alt1, Alt2, Alt6,
 };
 
 /// Type tags that designate a PWM pin output designation
@@ -98,4 +101,40 @@ impl Pin for GPIO_B0_11<Alt2> {
     type Output = output::B;
     type Module = module::_2; // FlexPWM2
     type Submodule = submodule::_2; // FlexPWM2
+}
+
+impl Pin for GPIO_B1_01<Alt6> {
+    type Output = output::B;
+    type Module = module::_1;
+    type Submodule = submodule::_3;
+}
+
+impl Pin for GPIO_B1_00<Alt6> {
+    type Output = output::A;
+    type Module = module::_1;
+    type Submodule = submodule::_3;
+}
+
+impl Pin for GPIO_EMC_04<Alt1> {
+    type Output = output::A;
+    type Module = module::_4;
+    type Submodule = submodule::_2;
+}
+
+impl Pin for GPIO_EMC_05<Alt1> {
+    type Output = output::B;
+    type Module = module::_4;
+    type Submodule = submodule::_2;
+}
+
+impl Pin for GPIO_EMC_06<Alt1> {
+    type Output = output::A;
+    type Module = module::_2;
+    type Submodule = submodule::_0;
+}
+
+impl Pin for GPIO_EMC_08<Alt1> {
+    type Output = output::A;
+    type Module = module::_2;
+    type Submodule = submodule::_1;
 }

--- a/imxrt1062-hal/src/lib.rs
+++ b/imxrt1062-hal/src/lib.rs
@@ -42,7 +42,10 @@ pub struct Peripherals {
     pub ccm: ccm::CCM,
     pub pit: pit::UnclockedPIT,
     pub dcdc: dcdc::DCDC,
+    pub pwm1: pwm::UnclockedController<pwm::module::_1>,
     pub pwm2: pwm::UnclockedController<pwm::module::_2>,
+    pub pwm3: pwm::UnclockedController<pwm::module::_3>,
+    pub pwm4: pwm::UnclockedController<pwm::module::_4>,
     pub i2c: i2c::Unclocked,
     pub uart: uart::Unclocked,
 }
@@ -61,7 +64,10 @@ impl Peripherals {
             ccm: ccm::CCM::new(p.CCM, p.CCM_ANALOG),
             pit: pit::UnclockedPIT::new(p.PIT),
             dcdc: dcdc::DCDC(p.DCDC),
+            pwm1: pwm::UnclockedController::new(),
             pwm2: pwm::UnclockedController::new(),
+            pwm3: pwm::UnclockedController::new(),
+            pwm4: pwm::UnclockedController::new(),
             i2c: i2c::Unclocked::new(),
             uart: uart::Unclocked {
                 uart1: p.LPUART1,

--- a/imxrt1062-hal/src/pwm.rs
+++ b/imxrt1062-hal/src/pwm.rs
@@ -306,9 +306,10 @@ where
     }
 
     fn get_duty(&self) -> Self::Duty {
-        // TODO not sure if that's right...
         let sm = <S as submodule::Submodule>::submodule(self.reg.0);
-        sm.smval3.read().bits()
+        let modulo: u32 = sm.smval1.read().bits() as u32;
+        let cval: u32 = sm.smval3.read().bits() as u32;
+        ((cval << 16) / (modulo + 1)) as u16
     }
 
     fn get_max_duty(&self) -> Self::Duty {
@@ -358,9 +359,10 @@ where
     }
 
     fn get_duty(&self) -> Self::Duty {
-        // TODO not sure if that's right...
         let sm = <S as submodule::Submodule>::submodule(self.reg.0);
-        sm.smval5.read().bits()
+        let modulo: u32 = sm.smval1.read().bits() as u32;
+        let cval: u32 = sm.smval5.read().bits() as u32;
+        ((cval << 16) / (modulo + 1)) as u16
     }
 
     fn get_max_duty(&self) -> Self::Duty {

--- a/teensy4-bsp/src/lib.rs
+++ b/teensy4-bsp/src/lib.rs
@@ -125,6 +125,14 @@ pub struct Pins {
     pub p0: hal::iomuxc::gpio::GPIO_AD_B0_03<hal::iomuxc::Alt5>,
     /// Pin 1
     pub p1: hal::iomuxc::gpio::GPIO_AD_B0_02<hal::iomuxc::Alt5>,
+    /// Pin 2
+    pub p2: hal::iomuxc::gpio::GPIO_EMC_04<hal::iomuxc::Alt5>,
+    /// Pin 3
+    pub p3: hal::iomuxc::gpio::GPIO_EMC_05<hal::iomuxc::Alt5>,
+    /// Pin 4
+    pub p4: hal::iomuxc::gpio::GPIO_EMC_06<hal::iomuxc::Alt5>,
+    /// Pin 5
+    pub p5: hal::iomuxc::gpio::GPIO_EMC_08<hal::iomuxc::Alt5>,
     /// Pin 6
     pub p6: hal::iomuxc::gpio::GPIO_B0_10<hal::iomuxc::Alt5>,
     /// Pin 7
@@ -157,6 +165,8 @@ pub struct Pins {
     pub p28: hal::iomuxc::gpio::GPIO_EMC_32<hal::iomuxc::Alt5>,
     /// Pin 29
     pub p29: hal::iomuxc::gpio::GPIO_EMC_31<hal::iomuxc::Alt5>,
+    /// Pin 33
+    pub p33: hal::iomuxc::gpio::GPIO_EMC_07<hal::iomuxc::Alt5>,
     /// Pin 36
     pub p36: hal::iomuxc::gpio::GPIO_SD_B0_01<hal::iomuxc::Alt5>,
     /// Pin 37
@@ -229,6 +239,10 @@ impl Peripherals {
             pins: Pins {
                 p0: p.iomuxc.gpio_ad_b0_03,
                 p1: p.iomuxc.gpio_ad_b0_02,
+                p2: p.iomuxc.gpio_emc_04,
+                p3: p.iomuxc.gpio_emc_05,
+                p4: p.iomuxc.gpio_emc_06,
+                p5: p.iomuxc.gpio_emc_08,
                 p6: p.iomuxc.gpio_b0_10,
                 p7: p.iomuxc.gpio_b1_01,
                 p8: p.iomuxc.gpio_b1_00,
@@ -245,6 +259,7 @@ impl Peripherals {
                 p25: p.iomuxc.gpio_ad_b0_13,
                 p28: p.iomuxc.gpio_emc_32,
                 p29: p.iomuxc.gpio_emc_31,
+                p33: p.iomuxc.gpio_emc_07,
                 p36: p.iomuxc.gpio_sd_b0_01,
                 p37: p.iomuxc.gpio_sd_b0_00,
             },

--- a/teensy4-bsp/src/lib.rs
+++ b/teensy4-bsp/src/lib.rs
@@ -175,8 +175,14 @@ pub struct Peripherals {
     pub usb: usb::USB,
     /// DCDC converters
     pub dcdc: hal::dcdc::DCDC,
+    /// PWM1 controller
+    pub pwm1: hal::pwm::UnclockedController<hal::pwm::module::_1>,
     /// PWM2 controller
     pub pwm2: hal::pwm::UnclockedController<hal::pwm::module::_2>,
+    /// PWM3 controller
+    pub pwm3: hal::pwm::UnclockedController<hal::pwm::module::_3>,
+    /// PWM4 controller
+    pub pwm4: hal::pwm::UnclockedController<hal::pwm::module::_4>,
     /// Teensy pins
     pub pins: Pins,
     /// Unclocked I2C peripherals
@@ -216,7 +222,10 @@ impl Peripherals {
             pit: p.pit,
             usb: usb::USB::new(),
             dcdc: p.dcdc,
+            pwm1: p.pwm1,
             pwm2: p.pwm2,
+            pwm3: p.pwm3,
+            pwm4: p.pwm4,
             pins: Pins {
                 p0: p.iomuxc.gpio_ad_b0_03,
                 p1: p.iomuxc.gpio_ad_b0_02,


### PR DESCRIPTION
The PR exposes more PWM pins, all of the PWM modules, and fixes the implementation of `PwmPin::get_duty()`.

Not all of the Teensy 4 PWM pins are exposed. That's because we haven't defined the pad and pad configurations in the HAL. We should tackle that separately. Or, we can keep adding pads as needed, which is what we've been doing so far.

Closes #44, closes #43.