### PR TITLE
Make Peripherals constructors public to support using RTFM

### DIFF
--- a/imxrt1062-hal/src/lib.rs
+++ b/imxrt1062-hal/src/lib.rs
@@ -59,7 +59,7 @@ impl Peripherals {
         Some(Peripherals::new(p, cp))
     }
 
-    fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
+    pub fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
         Peripherals {
             iomuxc: iomuxc::IOMUXC::new(p.IOMUXC),
             systick: cp.SYST,

--- a/teensy4-bsp/src/lib.rs
+++ b/teensy4-bsp/src/lib.rs
@@ -229,7 +229,9 @@ impl Peripherals {
         Some(Peripherals::new(p))
     }
 
-    fn new(mut p: hal::Peripherals) -> Peripherals {
+    /// Instantiate the system peripherals, given HAL peripherals that have been initialized in
+    /// some other way, e.g. managed by the RTFM framework.
+    pub fn new(mut p: hal::Peripherals) -> Peripherals {
         p.systick.disable_counter();
         p.systick
             .set_clock_source(cortex_m::peripheral::syst::SystClkSource::External);


### PR DESCRIPTION
I'm using RTFM which handles peripherals already, and hence I need to be able to inject the peripherals from the outside.