### PR TITLE
Support logging messages with arbitrary length and embedded newlines

### DIFF
--- a/teensy4-bsp/src/usb.rs
+++ b/teensy4-bsp/src/usb.rs
@@ -158,7 +158,7 @@ struct Writer;
 impl fmt::Write for Writer {
     fn write_str(&mut self, string: &str) -> fmt::Result {
         let mut at_linefeed = false;
-        for line in string.split("\n") {
+        for line in string.split('\n') {
             if at_linefeed {
                 usbsys::serial_write("\r\n");
             }

--- a/teensy4-bsp/src/usb.rs
+++ b/teensy4-bsp/src/usb.rs
@@ -136,9 +136,9 @@ impl ::log::Log for Logger {
     fn log(&self, record: &::log::Record) {
         if self.enabled(record.metadata()) {
             use core::fmt::Write;
-            write!(
+            writeln!(
                 Writer,
-                "[{} {}]: {}\r\n",
+                "[{} {}]: {}",
                 record.level(),
                 record.target(),
                 record.args()

--- a/teensy4-bsp/src/usb.rs
+++ b/teensy4-bsp/src/usb.rs
@@ -136,15 +136,14 @@ impl ::log::Log for Logger {
     fn log(&self, record: &::log::Record) {
         if self.enabled(record.metadata()) {
             use core::fmt::Write;
-            // Stack space for writing
-            let mut buffer = [0; 256];
-            let mut cursor = Cursor::new(&mut buffer);
-            write!(&mut cursor, "[{} {}]: ", record.level(), record.target()).expect("infallible");
-            usbsys::serial_write(&cursor);
-            cursor.clear();
-            writeln!(&mut cursor, "{}\r", record.args()).expect("infallible");
-            usbsys::serial_write(&cursor);
-            cursor.clear();
+            write!(
+                Writer,
+                "[{} {}]: {}\r\n",
+                record.level(),
+                record.target(),
+                record.args()
+            )
+            .expect("infallible");
         }
     }
 
@@ -153,37 +152,20 @@ impl ::log::Log for Logger {
     }
 }
 
-/// Custom cursor for writing into buffers
-struct Cursor<'a> {
-    buffer: &'a mut [u8],
-    offset: usize,
-}
+// TODO: make this public?
+struct Writer;
 
-impl<'a> Cursor<'a> {
-    fn new(buffer: &'a mut [u8]) -> Self {
-        Cursor { buffer, offset: 0 }
-    }
-
-    fn clear(&mut self) {
-        self.offset = 0;
-    }
-}
-
-impl<'a> fmt::Write for Cursor<'a> {
-    fn write_str(&mut self, msg: &str) -> fmt::Result {
-        let src = msg.as_bytes();
-        let buf = &mut self.buffer[self.offset..];
-        let len = core::cmp::min(buf.len(), src.len());
-        let buf = &mut buf[..len];
-        buf.copy_from_slice(src);
-        self.offset += len;
+impl fmt::Write for Writer {
+    fn write_str(&mut self, string: &str) -> fmt::Result {
+        let mut at_linefeed = false;
+        for line in string.split("\n") {
+            if at_linefeed {
+                usbsys::serial_write("\r\n");
+            }
+            usbsys::serial_write(line.as_bytes());
+            at_linefeed = true;
+        }
         Ok(())
-    }
-}
-
-impl<'a> AsRef<[u8]> for Cursor<'a> {
-    fn as_ref(&self) -> &[u8] {
-        &self.buffer[..self.offset]
     }
 }
 

--- a/teensy4-bsp/src/usb.rs
+++ b/teensy4-bsp/src/usb.rs
@@ -72,7 +72,7 @@ impl USB {
             usbsys::usb_init();
             cortex_m::peripheral::NVIC::unmask(crate::interrupt::USB_OTG1);
         }
-        Reader(())
+        Reader(core::marker::PhantomData)
     }
 
     /// # Safety
@@ -173,7 +173,8 @@ impl fmt::Write for Writer {
 }
 
 /// A type that can read USB serial messages from a host
-pub struct Reader(());
+// Uses a raw `*const ()` to ensure that Reader is not Send or Sync
+pub struct Reader(core::marker::PhantomData<*const ()>);
 
 /// OK to transfer across 'thread' boundaries, but not safe for
 /// multi-threaded access (Sync).

--- a/teensy4-bsp/src/usb.rs
+++ b/teensy4-bsp/src/usb.rs
@@ -162,7 +162,10 @@ impl fmt::Write for Writer {
             if at_linefeed {
                 usbsys::serial_write("\r\n");
             }
-            usbsys::serial_write(line.as_bytes());
+            let bytes = line.as_bytes();
+            if !bytes.is_empty() {
+                usbsys::serial_write(bytes);
+            }
             at_linefeed = true;
         }
         Ok(())

--- a/teensy4-bsp/src/usb.rs
+++ b/teensy4-bsp/src/usb.rs
@@ -72,7 +72,7 @@ impl USB {
             usbsys::usb_init();
             cortex_m::peripheral::NVIC::unmask(crate::interrupt::USB_OTG1);
         }
-        Reader(core::marker::PhantomData)
+        Reader(())
     }
 
     /// # Safety
@@ -188,7 +188,7 @@ impl<'a> AsRef<[u8]> for Cursor<'a> {
 }
 
 /// A type that can read USB serial messages from a host
-pub struct Reader(core::marker::PhantomData<*const ()>);
+pub struct Reader(());
 
 /// OK to transfer across 'thread' boundaries, but not safe for
 /// multi-threaded access (Sync).

--- a/teensy4-bsp/teensy4-usb-sys/src/lib.rs
+++ b/teensy4-bsp/teensy4-usb-sys/src/lib.rs
@@ -62,7 +62,7 @@ extern "C" {
 /// Writes the buffer of data to the USB host
 ///
 /// TODO error handling, return the number of bytes written, etc.
-pub fn serial_write<B: AsRef<[u8]>>(buffer: &B) {
+pub fn serial_write<B: AsRef<[u8]>>(buffer: B) {
     let buffer = buffer.as_ref();
     unsafe {
         usb_serial_write(buffer.as_ptr(), buffer.len() as u32);

--- a/teensy4-examples/src/spi.rs
+++ b/teensy4-examples/src/spi.rs
@@ -130,7 +130,7 @@ fn transact<'a, O: OutputPin, F: FnOnce() -> R + 'a, R>(cs: &'a mut O, act: F) -
 
 /// Creates a read instruction for the MPU9250
 const fn read(address: u8) -> u16 {
-    (((address as u16) | (1 << 7)) << 8)
+    ((address as u16) | (1 << 7)) << 8
 }
 
 /// Creates a write instruction for the MPU9250


### PR DESCRIPTION
Logging messages that are larger than 256 bytes currently cause panics.  Also, if the messages contain newlines, they are not broken over several lines as might be expected.

This fixes a few things in the logging stack.  I took the opportunity to remove one level of buffering which I don't think is needed, and simplified some type signatures.