### PR TITLE
Fix soft reboot

### DIFF
--- a/imxrt1062-rt/src/reset.c
+++ b/imxrt1062-rt/src/reset.c
@@ -43,7 +43,7 @@ zero_bss(uint32_t *sbss, const uint32_t *const ebss) {
 __attribute__((section(".boot.reset"), naked)) void _reset(void) {
   // Initialize TCM regions
   IOMUXC_GPR_GPR(17) = (uint32_t)&__flexram_bank_config;
-  IOMUXC_GPR_GPR(16) = 0x00000007;
+  IOMUXC_GPR_GPR(16) = 0x00200007;
   IOMUXC_GPR_GPR(14) = 0x00AA0000;
 
   // Reconfigure the stack pointer(s) based on the DTCM / ITCM separation


### PR DESCRIPTION
Previously it would just shut the Teensy 4 off.

See https://github.com/PaulStoffregen/cores/commit/d10668b560ef974fbac4e55249279f39e4b5bb72

To test, try this before and after:
```rust
const SCB_AIRCR: *mut u32 = 0xE000ED0C as *mut u32;
unsafe {
    core::ptr::write_volatile(SCB_AIRCR, 0x05FA0004);
}
```