### PR TITLE
Add a convenient `[patch]` crate for `cortex-m-rt` that re-exports `teensy4-rt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ Part of the teensy4-rs project.
 
 [dependencies]
 cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
 log = "0.4.8"
 teensy4-fcb = { path = "teensy4-fcb" }
-teensy4-rt = { path = "teensy4-rt" }
 teensy4-usb-sys = { path = "teensy4-usb-sys" }
 
 [dependencies.imxrt-hal]
@@ -28,6 +28,7 @@ panic-halt = "0.2.0"
 
 [workspace]
 members = [
+    "cortex-m-rt-patch",
     "teensy4-fcb",
     "teensy4-rt",
     "teensy4-usb-sys",
@@ -37,3 +38,8 @@ members = [
 # Helps with build times.
 [profile.release.build-override]
 opt-level = 0
+
+# Patch `cortex-m-rt` for reasons described here:
+# https://github.com/mciantyre/teensy4-rs#runtime
+[patch.crates-io.cortex-m-rt]
+path = "cortex-m-rt-patch"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ To support compatibility with the `cortex-m-rt` crate, the `teensy4-rt` crate us
 
 It is our hope that the `teensy4-rt` crate can be transparently replaced with the `cortext-m-rt` crate once the necessary features are available. If you think that the `teensy4-rt` crate is be diverging from the `cortex-m-rt` crate and might miss that goal, please file an issue!
 
+In the meantime, a patch for the `cortex-m-rt` crate is provided within the `cortex-m-rt-patch` directory. See [cortex-m-rt-patch/README.md](./cortex-m-rt-patch/README.md) for details on how to use the patch.
+
 ## Contributing
 
 We welcome support! A great way to contribute is to start using the crates to develop Teensy 4 applications. Submit an issue to help us identify bugs, feature requests, or documentation gaps. See [CONTRIBUTING.md](CONTRIBUTING.md) to learn about the best issue tracker for your request.

--- a/cortex-m-rt-patch/Cargo.toml
+++ b/cortex-m-rt-patch/Cargo.toml
@@ -1,0 +1,10 @@
+# NOTE: This is a temporary patch for `cortex-m-rt` - see the README.
+
+[package]
+name = "cortex-m-rt"
+version = "0.6.12"
+authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+teensy4-rt = { path = "../teensy4-rt" }

--- a/cortex-m-rt-patch/README.md
+++ b/cortex-m-rt-patch/README.md
@@ -1,0 +1,24 @@
+# `cortex-m-rt` patch for teensy4
+
+The sole purpose of this crate is to allow for patching the `cortex-m-rt`
+dependency of upstream crates with the `teensy4-rt` crate. To understand why
+this is necessary, please refer to [the Runtime section][1] of the top-level
+README.
+
+If you are looking for the repository of the real `cortex-m-rt` crate, see
+[here][2].
+
+## Usage
+
+Add the `[patch]` for `cortex-m-rt` to your project like so:
+
+```toml
+# Patch `cortex-m-rt` for reasons described here:
+# https://github.com/mciantyre/teensy4-rs#runtime
+[patch.crates-io.cortex-m-rt]
+git = "https://github.com/mciantyre/teensy4-rs"
+branch = "master"
+```
+
+[1]: https://github.com/mciantyre/teensy4-rs#runtime
+[2]: https://github.com/rust-embedded/cortex-m-rt

--- a/cortex-m-rt-patch/src/lib.rs
+++ b/cortex-m-rt-patch/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub use teensy4_rt::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@ pub mod usb;
 
 pub use hal::ral::interrupt;
 
+pub use cortex_m_rt as rt;
 pub use imxrt_hal as hal;
-pub use teensy4_rt as rt;
 
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO2IO03<hal::gpio::GPIO7, hal::gpio::Output>;
@@ -339,7 +339,7 @@ pub extern "C" fn delay(millis: u32) {
 
 /// Scoping of data related to SYSTICK
 mod systick {
-    use teensy4_rt::exception;
+    use crate::rt::exception;
 
     #[no_mangle]
     static mut systick_millis_count: u32 = 0;


### PR DESCRIPTION
This adds a `cortex-m-rt-patch` directory that contains a tiny crate that re-exports `teensy4-rt` in its entirety under the crate name `cortex-m-rt` to provide a convenient way of patching the `cortex-m-rt` dependency of upstream crates.

The hope is to make workarounds for issues like #62 a little easier pending solving rust-embedded/cortex-m-rt#164 and the reconciliation of `cortex-m-rt` and `teensy4-rt`.

I've also changed the `teensy4_bsp` crate to depend on `cortex-m-rt` and use this new patch crate. Hopefully this means that all we have to do once rust-embedded/cortex-m-rt#164 is solved is remove the `[patch]` entry.