### PR TITLE
Add BSP features for usb-logging and systick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ cortex-m = "0.6.2"
 cortex-m-rt = "0.6.12"
 log = "0.4.8"
 teensy4-fcb = { path = "teensy4-fcb" }
-teensy4-usb-sys = { path = "teensy4-usb-sys" }
+
+[dependencies.teensy4-usb-sys]
+path = "teensy4-usb-sys"
+optional = true
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
@@ -33,6 +36,19 @@ members = [
     "teensy4-rt",
     "teensy4-usb-sys",
 ]
+
+[features]
+# Default features established for prototype development
+default = ["usb-logging", "systick"]
+# Enables the USB logging stack
+#
+# This will introduce the teensy4-usb-sys bindings into the build
+# graph. It also requires systick, since the USB stack depends on
+# the systick counter for timekeeping.
+usb-logging = ["systick", "teensy4-usb-sys"]
+# Include a definition of the SysTick exception handler. This enables
+# a simple delay() spinloop that waits for the timer to elapse.
+systick = []
 
 # Don't optimize build dependencies, like proc macros.
 # Helps with build times.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ optional = true
 version = "0.3.0"
 features = ["imxrt1062", "rt"]
 
+[dependencies.embedded-hal]
+version = "0.2.4"
+optional = true
+
 [dev-dependencies]
 embedded-hal = "0.2.4"
 nb = "0.1.2"
@@ -48,7 +52,7 @@ default = ["usb-logging", "systick"]
 usb-logging = ["systick", "teensy4-usb-sys"]
 # Include a definition of the SysTick exception handler. This enables
 # a simple delay() spinloop that waits for the timer to elapse.
-systick = []
+systick = ["embedded-hal"]
 
 # Don't optimize build dependencies, like proc macros.
 # Helps with build times.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,27 @@ Part of the teensy4-rs project.
 
 [dependencies]
 cortex-m = "0.6.2"
-cortex-m-rt = "0.6.12"
-log = "0.4.8"
+cortex-m-rt = "0.6.12" # Note: not the 'real' cortex-m-rt
 teensy4-fcb = { path = "teensy4-fcb" }
-
-[dependencies.teensy4-usb-sys]
-path = "teensy4-usb-sys"
-optional = true
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
 features = ["imxrt1062", "rt"]
 
+# Tied to "systick" feature, since
+# SysTick implements a blocking delay trait
 [dependencies.embedded-hal]
 version = "0.2.4"
+optional = true
+
+# Only need logging when "usb-logging" is enabled
+[dependencies.log]
+version = "0.4.8"
+optional = true
+
+# Only needed when "usb-logging" is enabled
+[dependencies.teensy4-usb-sys]
+path = "teensy4-usb-sys"
 optional = true
 
 [dev-dependencies]
@@ -49,7 +56,7 @@ default = ["usb-logging", "systick"]
 # This will introduce the teensy4-usb-sys bindings into the build
 # graph. It also requires systick, since the USB stack depends on
 # the systick counter for timekeeping.
-usb-logging = ["systick", "teensy4-usb-sys"]
+usb-logging = ["systick", "teensy4-usb-sys", "log"]
 # Include a definition of the SysTick exception handler. This enables
 # a simple delay() spinloop that waits for the timer to elapse.
 systick = ["embedded-hal"]

--- a/examples/dma_memcpy.rs
+++ b/examples/dma_memcpy.rs
@@ -35,7 +35,7 @@ const NUMBER_OF_ELEMENTS: Element = (BUFFER_SIZE - 7) as Element;
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     peripherals.usb.init(Default::default());
-    bsp::delay(5_000);
+    peripherals.systick.delay(5_000);
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
     let channel = dma_channels[13].take().unwrap();
@@ -141,6 +141,6 @@ fn main() -> ! {
         tx_buffer.clear();
 
         start += 1;
-        bsp::delay(5_000);
+        peripherals.systick.delay(5_000);
     }
 }

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -182,7 +182,7 @@ fn main() -> ! {
     // SPI setup
     //
 
-    bsp::delay(5000);
+    peripherals.systick.delay(5000);
     log::info!("Initializing SPI4 clocks...");
 
     let (_, _, _, spi4_builder) = peripherals.spi.clock(
@@ -270,7 +270,7 @@ fn main() -> ! {
                 core::sync::atomic::spin_loop_hint();
             }
         }
-        bsp::delay(500);
+        peripherals.systick.delay(500);
 
         log::info!("Started DMA transfers for WHO_AM_I");
         FLAG.store(false, Ordering::Release);
@@ -322,7 +322,7 @@ fn main() -> ! {
             }
         }
 
-        bsp::delay(500);
+        peripherals.systick.delay(500);
         FLAG.store(false, Ordering::Release);
         prepare_transfer(spi);
         loop {

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -82,7 +82,7 @@ unsafe fn DMA7_DMA23() {
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     peripherals.usb.init(Default::default());
-    bsp::delay(5_000);
+    peripherals.systick.delay(5_000);
     let uarts = peripherals.uart.clock(
         &mut peripherals.ccm.handle,
         bsp::hal::ccm::uart::ClockSelect::OSC,

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -44,7 +44,7 @@ where
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     peripherals.usb.init(Default::default());
-    bsp::delay(5000);
+    peripherals.systick.delay(5000);
 
     log::info!("Enabling I2C clocks...");
     let (_, _, i2c3_builder, _) = peripherals.i2c.clock(
@@ -72,7 +72,7 @@ fn main() -> ! {
 
     log::info!("Starting I/O loop...");
     loop {
-        bsp::delay(1000);
+        peripherals.systick.delay(1000);
         log::info!("Querying WHO_AM_I...");
         match who_am_i(&mut i2c3) {
             Ok(who) => log::info!("Received 0x{:X} for WHO_AM_I", who),

--- a/examples/pit.rs
+++ b/examples/pit.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
     // with the WFI in the loop, maybe...? If I instead
     // busy-loop on an atomic U32, I don't crash in debug
     // builds.
-    bsp::delay(25);
+    periphs.systick.delay(25);
     let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
         bsp::hal::ccm::PLL1::ARM_HZ,
         &mut periphs.ccm.handle,

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -32,13 +32,13 @@ fn main() -> ! {
     // Initialize the logging, so we can use it in the PWM loop below
     p.usb.init(Default::default());
     // Delay is only to let a user set-up their USB serial connection...
-    bsp::delay(5000);
+    p.systick.delay(5000);
     // Set the core and IPG clock. The IPG clock frequency drives the PWM (sub)modules
     let (_, ipg_hz) =
         p.ccm
             .pll1
             .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    bsp::delay(100);
+    p.systick.delay(100);
     // Enable the clocks for the PWM2 module
     let mut pwm2 = p.pwm2.clock(&mut p.ccm.handle);
     // Get the outputs from the PWM2 module, submodule 2.
@@ -71,15 +71,15 @@ fn main() -> ! {
         ctrl.enable(Channel::B);
         ctrl.set_duty(Channel::A, duty1);
         ctrl.set_duty(Channel::B, duty2);
-        bsp::delay(200);
+        p.systick.delay(200);
 
         log::info!("Disabling 'B' PWM...");
         ctrl.disable(Channel::B);
-        bsp::delay(200);
+        p.systick.delay(200);
 
         log::info!("Disabling 'A' PWM...");
         ctrl.disable(Channel::A);
-        bsp::delay(400);
+        p.systick.delay(400);
 
         core::mem::swap(&mut duty1, &mut duty2);
     }

--- a/examples/systick.rs
+++ b/examples/systick.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
     let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
 
     loop {
-        bsp::delay(LED_PERIOD_MS);
+        p.systick.delay(LED_PERIOD_MS);
         led.toggle().unwrap();
     }
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -22,7 +22,7 @@ use teensy4_bsp as bsp;
 #[entry]
 fn main() -> ! {
     let mut periphs = bsp::Peripherals::take().unwrap();
-    bsp::delay(25);
+    periphs.systick.delay(25);
     periphs.usb.init(Default::default());
 
     let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
@@ -44,10 +44,11 @@ fn main() -> ! {
     let (timer0, timer1, _, mut timer3) = periphs.pit.clock(&mut cfg);
     let mut timer = pit::chain(timer0, timer1);
     let mut led: bsp::LED = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut systick = periphs.systick;
     loop {
         let (_, period) = timer.time(|| {
             led.set_high().unwrap();
-            bsp::delay(500);
+            systick.delay(500);
             led.set_low().unwrap();
         });
         match period {
@@ -55,7 +56,7 @@ fn main() -> ! {
             None => log::warn!("Lifetime timer expired!"),
         };
 
-        bsp::delay(100);
+        systick.delay(100);
 
         timer3.start(core::time::Duration::from_micros(200));
         let (_, period) = gpt2.time(|| {
@@ -65,6 +66,6 @@ fn main() -> ! {
         });
         log::info!("GPT2 timed a {:?} long event", period);
 
-        bsp::delay(100);
+        systick.delay(100);
     }
 }

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -81,7 +81,7 @@ fn read<R: Read<u8>>(uart: &mut R, bytes: &mut [u8]) -> Result<(), R::Error> {
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     peripherals.usb.init(Default::default());
-    bsp::delay(5_000);
+    peripherals.systick.delay(5_000);
     let uarts = peripherals.uart.clock(
         &mut peripherals.ccm.handle,
         bsp::hal::ccm::uart::ClockSelect::OSC,
@@ -105,11 +105,11 @@ fn main() -> ! {
     let mut led = bsp::configure_led(&mut peripherals.gpr, peripherals.pins.p13);
     let (mut tx, mut rx) = uart.split();
     loop {
-        bsp::delay(1_000);
+        peripherals.systick.delay(1_000);
         led.toggle().unwrap();
         let mut buffer = DATA;
         write(&mut tx, &buffer).unwrap();
-        bsp::delay(1);
+        peripherals.systick.delay(1);
         match read(&mut rx, &mut buffer) {
             Ok(_) => continue,
             Err(err) => log::warn!("Receiver error: {:?}", err.flags),

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
         filters: &[("usb", None)],
         ..Default::default()
     });
-    bsp::delay(2000);
+    p.systick.delay(2000);
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
@@ -50,6 +50,6 @@ fn main() -> ! {
         log::debug!("Sleeping for 1 second...");
         log::trace!("{} + {} = {}", 3, 2, 3 + 2);
         led.toggle().unwrap();
-        bsp::delay(5000);
+        p.systick.delay(5000);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ pub struct Pins {
 /// - `pins`, which are the Teensy 4's available pins
 ///
 /// See the [module-level documentation](index.html) for more information.
+#[non_exhaustive]
 pub struct Peripherals {
     /// Clock control module (forwarded from the HAL)
     pub ccm: hal::ccm::CCM,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,14 @@
 //! for more details.
 //!
 //! The BSP does assume some facilities of the processor, both which are required for the
-//! USB stack:
+//! USB stack. Each are controllable through feature-flags. Each feature is on by default.
 //!
 //! - it registers the `SysTick` exception handler, and configures
-//!   SYSTICK for a 1ms interrupt.
+//!   SYSTICK for a 1ms interrupt. Enabled with the `"systick"` feature,
+//!   which is on by default.
 //! - it registers the `USB_OTG1` interrupt, and uses the USB1
-//!   peripheral for logging.
+//!   peripheral for logging. Enabled with the `"usb-logging"` feature,
+//!   which is on by default. Depends on the `"systick"` feature.
 //!
 //! These peripherals and capabilities are not exported from the BSP.
 //! If a user also registers a `SysTick` or `USB_OTG1` handler, it may
@@ -108,6 +110,7 @@
 // Need to reference this so that it doesn't get stripped out
 extern crate teensy4_fcb;
 
+#[cfg(feature = "usb-logging")]
 pub mod usb;
 
 pub use hal::ral::interrupt;
@@ -200,6 +203,7 @@ pub struct Peripherals {
     /// PIT timers (forwarded from the HAL)
     pub pit: hal::pit::UnclockedPIT,
     /// The USB logger and serial reader
+    #[cfg(feature = "usb-logging")]
     pub usb: usb::USB,
     /// DCDC converters
     pub dcdc: hal::dcdc::DCDC,
@@ -258,6 +262,7 @@ impl Peripherals {
         Peripherals {
             ccm: p.ccm,
             pit: p.pit,
+            #[cfg(feature = "usb-logging")]
             usb: usb::USB::new(),
             dcdc: p.dcdc,
             pwm1: p.pwm1,
@@ -322,6 +327,7 @@ pub fn configure_led<A>(gpr: &mut hal::iomuxc::GPR, pad: hal::iomuxc::gpio::GPIO
 /// `delay()` will spin-loop on updates from SYSTICK, until
 /// `millis` milliseconds have elapsed. SYSTICK has a 1ms
 /// interrupt interval, so the minimal delay is around 1ms.
+#[cfg(feature = "systick")]
 #[no_mangle]
 pub extern "C" fn delay(millis: u32) {
     if 0 == millis {
@@ -338,6 +344,7 @@ pub extern "C" fn delay(millis: u32) {
 }
 
 /// Scoping of data related to SYSTICK
+#[cfg(feature = "systick")]
 mod systick {
     use crate::rt::exception;
 

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -1,0 +1,68 @@
+//! System tick and delay support
+//!
+//! If we're compiling this module, it's because the `"systick"` feature
+//! is enabled.
+
+use crate::rt::exception;
+
+#[no_mangle]
+static mut systick_millis_count: u32 = 0;
+
+#[exception]
+fn SysTick() {
+    unsafe {
+        let ms = core::ptr::read_volatile(&systick_millis_count);
+        let ms = ms.wrapping_add(1);
+        core::ptr::write_volatile(&mut systick_millis_count, ms);
+    }
+}
+
+/// Read the systick counter. Returns an absolute value describing
+/// the number of milliseconds since the SYSTICK handler was enabled.
+/// This may be used to implement coarse timing.
+pub fn read() -> u32 {
+    unsafe { core::ptr::read_volatile(&systick_millis_count) }
+}
+
+/// Blocks for at least `millis` milliseconds
+///
+/// `delay()` will spin-loop on updates from SYSTICK, until
+/// `millis` milliseconds have elapsed. SYSTICK has a 1ms
+/// interrupt interval, so the minimal delay is around 1ms.
+#[no_mangle]
+pub extern "C" fn delay(millis: u32) {
+    if 0 == millis {
+        return;
+    }
+    let start = read();
+    let target = start + millis;
+    loop {
+        let count = read();
+        if count >= target {
+            return;
+        }
+    }
+}
+
+/// A type that represents the system timer, SYSTICK
+///
+/// `SysTick` implements the `embedded_hal`'s `DelayMs` trait. It
+/// may be used to implement simple, blocking delays.
+pub struct SysTick(());
+
+impl SysTick {
+    pub(crate) fn new() -> Self {
+        SysTick(())
+    }
+
+    /// Blocks for `ms` milliseconds
+    pub fn delay(&mut self, ms: u32) {
+        self::delay(ms);
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayMs<u32> for SysTick {
+    fn delay_ms(&mut self, ms: u32) {
+        self::delay(ms);
+    }
+}


### PR DESCRIPTION
See the discussions on #64. This PR adds two, default features for the `teensy4-bsp`:

- `"usb-logging"` enables the USB logging capabilities. Depends on `"systick"`.
- `"systick"` enables the BSP's definition of the SYSTICK exception handler.

The goal is to keep features additive, as expected by cargo. At the same time, we keep the two features enabled by default for backwards compatibility.

#64 proposes that we add RTIC support behind a new feature, `"rtic"`. If this is accepted, users will have to *disable default features* before safely enabling the `"rtic"` feature.

This also knocks-out #36, since we were messing with SYSTICK.