### PR TITLE
[WIP] `rtic-usb` example - demonstrate read/write on the Teensy 4.0 USB and the `USB_OTG1` interrupt

### DIFF
--- a/examples/rtic_usb.rs
+++ b/examples/rtic_usb.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::ToggleableOutputPin;
+use panic_halt as _;
+use teensy4_bsp as bsp;
+
+#[rtic::app(device = teensy4_bsp, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        led: bsp::LED,
+    }
+
+    #[init]
+    fn init(mut cx: init::Context) -> init::LateResources {
+        init_delay();
+
+        // Initialize the USB stack with the default logging settings.
+        let usb_rx = cx.device.usb.init(bsp::usb::LoggingConfig {
+            filters: &[("usb", None)],
+            ..Default::default()
+        });
+
+        let led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        init::LateResources { led }
+    }
+
+    #[task(binds = USB_OTG1, resources = [led])]
+    fn usb(cx: usb::Context) {
+        cx.resources.led.toggle().unwrap();
+    }
+
+    #[idle]
+    fn idle(_cx: idle::Context) -> ! {
+        loop {
+            core::sync::atomic::spin_loop_hint();
+        }
+    }
+};
+
+// If we reach WFI on teensy 4.0 too quickly it seems to halt. Here we wait a short while in `init`
+// to avoid this issue. The issue only appears to occur when rebooting the device (via the button),
+// however there appears to be no issue when power cycling the device.
+//
+// TODO: Investigate exactly why this appears to be necessary.
+fn init_delay() {
+    for _ in 0..10_000_000 {
+        core::sync::atomic::spin_loop_hint();
+    }
+}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -8,9 +8,11 @@
 //!
 //! [`log`]: https://crates.io/crates/log
 
-use crate::interrupt; // bring in interrupt variants for #[interrupt] macro
 use core::fmt;
 use teensy4_usb_sys as usbsys;
+
+#[cfg(not(feature = "rtic"))]
+use crate::interrupt; // bring in interrupt variants for #[interrupt] macro
 
 /// Logging configuration
 ///
@@ -86,6 +88,7 @@ impl USB {
     }
 }
 
+#[cfg(not(feature = "rtic"))]
 #[crate::rt::interrupt]
 fn USB_OTG1() {
     unsafe {


### PR DESCRIPTION
This is currently not working and the program terminates on `usb.init` as discussed [here](https://github.com/mciantyre/teensy4-rs/pull/64#issuecomment-653602374). Still, I thought I'd post progress here in case anyone else diving into this would like a head start.

Eventually I hope to come back to this, but my current priority is writing a lib for the TMC2209 motor driver.