### PR TITLE
Integrate i.MX RT IOMUXC driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ teensy4-fcb = { path = "teensy4-fcb" }
 [dependencies.imxrt-hal]
 version = "0.3.0"
 git = "https://github.com/imxrt-rs/imxrt-rs.git"
-branch = "iomuxc-integration"
+rev = "1815db6"
 features = ["imxrt1062", "rt"]
 
 # Tied to "systick" feature, since
@@ -106,9 +106,3 @@ opt-level = 0
 [patch.crates-io.cortex-m-rt]
 path = "cortex-m-rt-patch"
 
-# Patch `imxrt-hal` so that we may access the `hal::Peripherals::steal`
-# constructor. This patch should be removed once a new version of
-# `imxrt-hal` is published with the new constructor.
-[patch.crates-io.imxrt-hal]
-git = "https://github.com/imxrt-rs/imxrt-rs"
-rev = "0305aed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,14 @@ teensy4-fcb = { path = "teensy4-fcb" }
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
+path = "../imxrt/imxrt/imxrt-hal"
 features = ["imxrt1062", "rt"]
+
+[dependencies.imxrt-iomuxc]
+path = "../imxrt/iomuxc"
+
+[dependencies.imxrt106x-iomuxc]
+path = "../imxrt/iomuxc/imxrt106x-iomuxc"
 
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
@@ -48,14 +55,17 @@ panic-halt = "0.2.0"
 name = "rtic_led"
 path = "examples/rtic_led.rs"
 required-features = ["rtic"]
+
 [[example]]
 name = "rtic_blink"
 path = "examples/rtic_blink.rs"
 required-features = ["rtic"]
+
 [[example]]
 name = "rtic_uart_log"
 path = "examples/rtic_uart_log.rs"
 required-features = ["rtic"]
+
 [[example]]
 name = "rtic_dma_uart_log"
 path = "examples/rtic_dma_uart_log.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ teensy4-fcb = { path = "teensy4-fcb" }
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
-path = "../imxrt/imxrt/imxrt-hal"
+git = "https://github.com/imxrt-rs/imxrt-rs.git"
+branch = "iomuxc-integration"
 features = ["imxrt1062", "rt"]
 
 # Tied to "systick" feature, since

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,6 @@ version = "0.3.0"
 path = "../imxrt/imxrt/imxrt-hal"
 features = ["imxrt1062", "rt"]
 
-[dependencies.imxrt-iomuxc]
-path = "../imxrt/iomuxc"
-
-[dependencies.imxrt106x-iomuxc]
-path = "../imxrt/iomuxc/imxrt106x-iomuxc"
-
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
 [dependencies.embedded-hal]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ git = "https://github.com/imxrt-rs/imxrt-rs.git"
 rev = "1815db6"
 features = ["imxrt1062", "rt"]
 
+[dev-dependencies.imxrt-uart-log]
+git = "https://github.com/imxrt-rs/imxrt-uart-log.git"
+
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
 [dependencies.embedded-hal]
@@ -42,7 +45,6 @@ cortex-m-rtic = "0.5.3"
 embedded-hal = "0.2.4"
 heapless = "0.5.5"
 log = "0.4.8"
-imxrt-uart-log = "0.1.0"
 nb = "0.1.2"
 panic-halt = "0.2.0"
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ endif # INSTALL_DEPS != 0
 
 TARGET_EXAMPLES := target/thumbv7em-none-eabihf/release/examples
 EXAMPLES := $(shell ls examples | xargs basename | cut -f 1 -d .)
+RTIC_EXAMPLES := $(shell ls examples | grep rtic | xargs basename | cut -f 1 -d .)
 
 .PHONY: all
 all:
@@ -42,6 +43,14 @@ all:
 	@for example in $(EXAMPLES);\
 		do cargo objcopy $(MODE) --example $$example \
 			-- -O ihex $(TARGET_EXAMPLES)/$$example.hex;\
+		done
+
+# Build all RTIC-related examples
+.PHONY: rtic
+rtic:
+	@for example in $(RTIC_EXAMPLES);\
+		do cargo build $(MODE) --example $$example \
+			--no-default-features --features=rtic;\
 		done
 
 .PHONY: example_%

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -80,7 +80,7 @@ static TX_BUFFER: Mutex<RefCell<Option<TxBuffer>>> = Mutex::new(RefCell::new(Non
 static RX_BUFFER: Mutex<RefCell<Option<RxBuffer>>> = Mutex::new(RefCell::new(None));
 
 type SpiDma =
-    dma::Peripheral<bsp::hal::spi::SPI<imxrt_iomuxc::consts::U4>, u16, TxBuffer, RxBuffer>;
+    dma::Peripheral<bsp::hal::spi::SPI<bsp::hal::iomuxc::consts::U4>, u16, TxBuffer, RxBuffer>;
 
 // TODO types should be Send
 static mut SPI_DMA: Option<SpiDma> = None;
@@ -158,7 +158,7 @@ fn rx_buffer_mut<F: FnOnce(&mut RxBuffer) -> R, R>(act: F) -> Option<R> {
 }
 
 // Pin 20
-type HardwareFlag = bsp::hal::gpio::GPIO<imxrt106x_iomuxc::ad_b1::AD_B1_10, bsp::hal::gpio::Output>;
+type HardwareFlag = bsp::hal::gpio::GPIO<bsp::hal::iomuxc::ad_b1::AD_B1_10, bsp::hal::gpio::Output>;
 static mut HARDWARE_FLAG: Option<HardwareFlag> = None;
 
 #[entry]

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -80,7 +80,7 @@ static TX_BUFFER: Mutex<RefCell<Option<TxBuffer>>> = Mutex::new(RefCell::new(Non
 static RX_BUFFER: Mutex<RefCell<Option<RxBuffer>>> = Mutex::new(RefCell::new(None));
 
 type SpiDma =
-    dma::Peripheral<bsp::hal::spi::SPI<bsp::hal::spi::module::_4>, u16, TxBuffer, RxBuffer>;
+    dma::Peripheral<bsp::hal::spi::SPI<imxrt_iomuxc::consts::U4>, u16, TxBuffer, RxBuffer>;
 
 // TODO types should be Send
 static mut SPI_DMA: Option<SpiDma> = None;
@@ -158,7 +158,7 @@ fn rx_buffer_mut<F: FnOnce(&mut RxBuffer) -> R, R>(act: F) -> Option<R> {
 }
 
 // Pin 20
-type HardwareFlag = bsp::hal::gpio::GPIO1IO26<bsp::hal::gpio::GPIO1, bsp::hal::gpio::Output>;
+type HardwareFlag = bsp::hal::gpio::GPIO<imxrt106x_iomuxc::ad_b1::AD_B1_10, bsp::hal::gpio::Output>;
 static mut HARDWARE_FLAG: Option<HardwareFlag> = None;
 
 #[entry]
@@ -174,8 +174,7 @@ fn main() -> ! {
 
     unsafe {
         let p20 = peripherals.pins.p20;
-        use bsp::hal::gpio::IntoGpio;
-        HARDWARE_FLAG = Some(p20.alt5().into_gpio().output());
+        HARDWARE_FLAG = Some(bsp::hal::gpio::GPIO::new(p20).output());
     }
 
     //
@@ -193,11 +192,11 @@ fn main() -> ! {
 
     log::info!("Constructing SPI4 peripheral...");
     let mut spi4 = spi4_builder.build(
-        peripherals.pins.p11.alt3(),
-        peripherals.pins.p12.alt3(),
-        peripherals.pins.p13.alt3(),
+        peripherals.pins.p11,
+        peripherals.pins.p12,
+        peripherals.pins.p13,
     );
-    spi4.enable_chip_select_0(peripherals.pins.p10.alt3());
+    spi4.enable_chip_select_0(peripherals.pins.p10);
 
     match spi4.set_clock_speed(bsp::hal::spi::ClockSpeed(SPI_BAUD_RATE_HZ)) {
         Ok(()) => {

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -220,20 +220,14 @@ fn main() -> ! {
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
     let tx_channel = dma_channels[9].take().unwrap();
-    let rx_channel = dma_channels[25].take().unwrap();
-    let rx_config = dma::ConfigBuilder::new()
-        .interrupt_on_completion(true)
-        .build();
+    let mut rx_channel = dma_channels[25].take().unwrap();
+    rx_channel.set_interrupt_on_completion(true);
 
     // We only want to interrupt when the receive completes. When
     // the receive completes, we know that we're also done transferring
     // data.
     let spi = unsafe {
-        SPI_DMA = Some(dma::bidirectional_u16(
-            spi4,
-            (tx_channel, dma::ConfigBuilder::new().build()),
-            (rx_channel, rx_config),
-        ));
+        SPI_DMA = Some(dma::bidirectional_u16(spi4, tx_channel, rx_channel));
         cortex_m::peripheral::NVIC::unmask(interrupt::DMA9_DMA25);
         SPI_DMA.as_mut().unwrap()
     };

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -92,18 +92,15 @@ fn main() -> ! {
         .unwrap();
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
-    let tx_channel = dma_channels[7].take().unwrap();
-    let rx_channel = dma_channels[23].take().unwrap();
+    let mut tx_channel = dma_channels[7].take().unwrap();
+    let mut rx_channel = dma_channels[23].take().unwrap();
 
-    let config = bsp::hal::dma::ConfigBuilder::new()
-        .interrupt_on_completion(true)
-        .build();
+    tx_channel.set_interrupt_on_completion(true);
+    rx_channel.set_interrupt_on_completion(true);
 
     let dma_uart = unsafe {
         DMA_PERIPHERAL = Some(bsp::hal::dma::Peripheral::new_bidirectional(
-            uart,
-            (tx_channel, config),
-            (rx_channel, config),
+            uart, tx_channel, rx_channel,
         ));
         cortex_m::peripheral::NVIC::unmask(interrupt::DMA7_DMA23);
         DMA_PERIPHERAL.as_mut().unwrap()

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -40,7 +40,7 @@ static TX_BUFFER: Mutex<RefCell<Option<TxBuffer>>> = Mutex::new(RefCell::new(Non
 static RX_BUFFER: Mutex<RefCell<Option<RxBuffer>>> = Mutex::new(RefCell::new(None));
 
 type DmaUart = bsp::hal::dma::Peripheral<
-    bsp::hal::uart::UART<imxrt_iomuxc::consts::U2>,
+    bsp::hal::uart::UART<bsp::hal::iomuxc::consts::U2>,
     u8,
     TxBuffer,
     RxBuffer,

--- a/examples/gpt.rs
+++ b/examples/gpt.rs
@@ -11,7 +11,6 @@ extern crate panic_halt;
 use bsp::hal::gpt;
 use bsp::interrupt;
 use bsp::rt::{entry, interrupt};
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use teensy4_bsp as bsp;
 
 use core::time::Duration;
@@ -53,13 +52,13 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
     }
 
-    let mut led = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut led = bsp::configure_led(periphs.pins.p13);
     loop {
         let gpt1 = unsafe { TIMER.as_mut().unwrap() };
         gpt1.set_enable(false);
         gpt1.set_output_compare_duration(OCR, Duration::from_millis(400));
         gpt1.set_enable(true);
         cortex_m::asm::wfi();
-        led.toggle().unwrap();
+        led.toggle();
     }
 }

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
     );
 
     log::info!("Constructing I2C3 instance on pins 16 and 17...");
-    let mut i2c3 = i2c3_builder.build(peripherals.pins.p16.alt1(), peripherals.pins.p17.alt1());
+    let mut i2c3 = i2c3_builder.build(peripherals.pins.p16, peripherals.pins.p17);
 
     if let Err(err) = i2c3.set_bus_idle_timeout(core::time::Duration::from_micros(200)) {
         log::warn!("Error when setting bus idle timeout: {:?}", err);
@@ -71,11 +71,13 @@ fn main() -> ! {
     }
 
     log::info!("Starting I/O loop...");
+    let mut counter = 0;
     loop {
         peripherals.systick.delay(1000);
         log::info!("Querying WHO_AM_I...");
+        counter += 1;
         match who_am_i(&mut i2c3) {
-            Ok(who) => log::info!("Received 0x{:X} for WHO_AM_I", who),
+            Ok(who) => log::info!("Received 0x{:X} for WHO_AM_I (iter = {})", who, counter),
             Err(err) => {
                 log::warn!("Error reading WHO_AM_I: {:?}", err);
                 continue;

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -15,8 +15,8 @@ use embedded_hal::digital::v2::OutputPin;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = bsp::Peripherals::take().unwrap();
-    let mut led = bsp::configure_led(&mut peripherals.gpr, peripherals.pins.p13);
+    let peripherals = bsp::Peripherals::take().unwrap();
+    let mut led = bsp::configure_led(peripherals.pins.p13);
 
     loop {
         led.set_high().unwrap();

--- a/examples/pit.rs
+++ b/examples/pit.rs
@@ -13,7 +13,7 @@ extern crate panic_halt;
 use bsp::hal::pit;
 use bsp::interrupt;
 use bsp::rt::{entry, interrupt};
-use embedded_hal::{digital::v2::ToggleableOutputPin, timer::CountDown};
+use embedded_hal::timer::CountDown;
 use teensy4_bsp as bsp;
 
 static mut TIMER: Option<pit::PIT<pit::channel::_3>> = None;
@@ -77,9 +77,9 @@ fn main() -> ! {
             .start(core::time::Duration::from_millis(250));
         cortex_m::peripheral::NVIC::unmask(interrupt::PIT);
     }
-    let mut led = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut led = bsp::configure_led(periphs.pins.p13);
     loop {
-        led.toggle().unwrap();
+        led.toggle();
         cortex_m::asm::wfi();
     }
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -47,8 +47,8 @@ fn main() -> ! {
         .sm2
         .outputs(
             &mut pwm2.handle,
-            p.pins.p6.alt2(),
-            p.pins.p9.alt2(),
+            p.pins.p6,
+            p.pins.p9,
             bsp::hal::pwm::Timing {
                 clock_select: bsp::hal::ccm::pwm::ClockSelect::IPG(ipg_hz),
                 prescalar: bsp::hal::ccm::pwm::Prescalar::PRSC_5,

--- a/examples/rtic_blink.rs
+++ b/examples/rtic_blink.rs
@@ -10,7 +10,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::OutputPin;
 use panic_halt as _;
 use rtic::cyccnt::U32Ext;
 use teensy4_bsp as bsp;
@@ -54,7 +54,7 @@ const APP: () = {
         // Schedule the first blink.
         cx.schedule.blink(cx.start + PERIOD.cycles()).unwrap();
 
-        let mut led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        let mut led = bsp::configure_led(cx.device.pins.p13);
         led.set_high().unwrap();
 
         init::LateResources { led }
@@ -62,7 +62,7 @@ const APP: () = {
 
     #[task(resources = [led], schedule = [blink])]
     fn blink(cx: blink::Context) {
-        cx.resources.led.toggle().unwrap();
+        cx.resources.led.toggle();
         // Schedule the following blink.
         cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();
     }

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -41,7 +41,7 @@ type Producer = heapless::spsc::Producer<'static, Ty, Cap>;
 type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 
 // The UART receiver.
-type UartRx = bsp::hal::uart::Rx<imxrt_iomuxc::consts::U2>;
+type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -149,7 +149,7 @@ const APP: () = {
     #[task(binds = DMA7_DMA23, resources = [dma_interrupt_count])]
     fn dma7_dma23(cx: dma7_dma23::Context) {
         *cx.resources.dma_interrupt_count += 1;
-        imxrt_uart_log::dma::poll()
+        imxrt_uart_log::dma::poll();
     }
 
     // RTIC requires that unused interrupts are declared in an extern block when

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -22,7 +22,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::serial::Read;
 use heapless::consts::U256;
 use panic_halt as _;
@@ -41,7 +41,7 @@ type Producer = heapless::spsc::Producer<'static, Ty, Cap>;
 type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 
 // The UART receiver.
-type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::uart::module::_2>;
+type UartRx = bsp::hal::uart::Rx<imxrt_iomuxc::consts::U2>;
 
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
@@ -78,7 +78,7 @@ const APP: () = {
         );
         let mut uart = uarts
             .uart2
-            .init(cx.device.pins.p14.alt2(), cx.device.pins.p15.alt2(), BAUD)
+            .init(cx.device.pins.p14, cx.device.pins.p15, BAUD)
             .unwrap();
         uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
         uart.set_rx_fifo(true);
@@ -93,7 +93,7 @@ const APP: () = {
         let (q_tx, q_rx) = unsafe { Q.split() };
 
         // LED setup.
-        let mut led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        let mut led = bsp::configure_led(cx.device.pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.
@@ -132,7 +132,7 @@ const APP: () = {
         }
 
         // Toggle the LED.
-        cx.resources.led.toggle().unwrap();
+        cx.resources.led.toggle();
 
         // Schedule the following blink.
         cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();

--- a/examples/rtic_led.rs
+++ b/examples/rtic_led.rs
@@ -24,9 +24,9 @@ const APP: () = {
         let _core: cortex_m::Peripherals = cx.core;
 
         // Device-specific peripherals
-        let mut device: bsp::Peripherals = cx.device;
+        let device: bsp::Peripherals = cx.device;
 
-        let mut led = bsp::configure_led(&mut device.gpr, device.pins.p13);
+        let mut led = bsp::configure_led(device.pins.p13);
         led.set_high().unwrap();
     }
     #[idle]

--- a/examples/rtic_uart_log.rs
+++ b/examples/rtic_uart_log.rs
@@ -16,7 +16,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::serial::Read;
 use heapless::consts::U256;
 use panic_halt as _;
@@ -35,7 +35,7 @@ type Producer = heapless::spsc::Producer<'static, Ty, Cap>;
 type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 
 // The UART receiver.
-type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::uart::module::_2>;
+type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
@@ -67,7 +67,7 @@ const APP: () = {
         );
         let mut uart = uarts
             .uart2
-            .init(cx.device.pins.p14.alt2(), cx.device.pins.p15.alt2(), BAUD)
+            .init(cx.device.pins.p14, cx.device.pins.p15, BAUD)
             .unwrap();
         uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
         uart.set_rx_fifo(true);
@@ -80,7 +80,7 @@ const APP: () = {
         let (q_tx, q_rx) = unsafe { Q.split() };
 
         // LED setup.
-        let mut led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        let mut led = bsp::configure_led(cx.device.pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.
@@ -119,7 +119,7 @@ const APP: () = {
         }
 
         // Toggle the LED.
-        cx.resources.led.toggle().unwrap();
+        cx.resources.led.toggle();
 
         // Schedule the following blink.
         cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -52,9 +52,9 @@ fn main() -> ! {
 
     log::info!("Constructing SPI4 peripheral...");
     let mut spi4 = spi4_builder.build(
-        peripherals.pins.p11.alt3(),
-        peripherals.pins.p12.alt3(),
-        peripherals.pins.p13.alt3(),
+        peripherals.pins.p11,
+        peripherals.pins.p12,
+        peripherals.pins.p13,
     );
 
     match spi4.set_clock_speed(bsp::hal::spi::ClockSpeed(SPI_BAUD_RATE_HZ)) {
@@ -76,7 +76,7 @@ fn main() -> ! {
     // We're using the SPI's default chip select pin. This uses a
     // dummy `OutputPin` that does nothing! If you'd rather use any
     // GPIO, replace this line to construct a GPIO from another pin.
-    spi4.enable_chip_select_0(peripherals.pins.p10.alt3());
+    spi4.enable_chip_select_0(peripherals.pins.p10);
     struct DummyCS;
     impl embedded_hal::digital::v2::OutputPin for DummyCS {
         type Error = core::convert::Infallible;

--- a/examples/systick.rs
+++ b/examples/systick.rs
@@ -9,7 +9,6 @@
 extern crate panic_halt;
 
 use bsp::rt;
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use teensy4_bsp as bsp;
 
 const LED_PERIOD_MS: u32 = 1_000;
@@ -17,10 +16,10 @@ const LED_PERIOD_MS: u32 = 1_000;
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
-    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
 
     loop {
         p.systick.delay(LED_PERIOD_MS);
-        led.toggle().unwrap();
+        led.toggle();
     }
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
 
     let (timer0, timer1, _, mut timer3) = periphs.pit.clock(&mut cfg);
     let mut timer = pit::chain(timer0, timer1);
-    let mut led: bsp::LED = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(periphs.pins.p13);
     let mut systick = periphs.systick;
     loop {
         let (_, period) = timer.time(|| {

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -23,7 +23,6 @@ extern crate panic_halt;
 use bsp::rt::entry;
 use teensy4_bsp as bsp;
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use embedded_hal::serial::{Read, Write};
 
 const BAUD: u32 = 115_200;
@@ -89,11 +88,7 @@ fn main() -> ! {
     );
     let mut uart = uarts
         .uart2
-        .init(
-            peripherals.pins.p14.alt2(),
-            peripherals.pins.p15.alt2(),
-            BAUD,
-        )
+        .init(peripherals.pins.p14, peripherals.pins.p15, BAUD)
         .unwrap();
     let fifo_size = uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
     log::info!("Setting TX FIFO to {}", fifo_size);
@@ -102,11 +97,11 @@ fn main() -> ! {
     uart.set_parity(PARITY);
     uart.set_rx_inversion(INVERTED);
     uart.set_tx_inversion(INVERTED);
-    let mut led = bsp::configure_led(&mut peripherals.gpr, peripherals.pins.p13);
+    let mut led = bsp::configure_led(peripherals.pins.p13);
     let (mut tx, mut rx) = uart.split();
     loop {
         peripherals.systick.delay(1_000);
-        led.toggle().unwrap();
+        led.toggle();
         let mut buffer = DATA;
         write(&mut tx, &buffer).unwrap();
         peripherals.systick.delay(1);

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -13,8 +13,6 @@ extern crate panic_halt;
 use bsp::rt;
 use teensy4_bsp as bsp;
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
-
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
@@ -27,7 +25,7 @@ fn main() -> ! {
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
     let mut buffer = [0; 256];
     loop {
         let bytes_read = usb_reader.read(&mut buffer);
@@ -49,7 +47,7 @@ fn main() -> ! {
         log::info!("It's 31'C outside");
         log::debug!("Sleeping for 1 second...");
         log::trace!("{} + {} = {}", 3, 2, 3 + 2);
-        led.toggle().unwrap();
+        led.toggle();
         p.systick.delay(5000);
     }
 }

--- a/examples/usb_writer.rs
+++ b/examples/usb_writer.rs
@@ -10,8 +10,6 @@ use bsp::rt;
 use core::fmt::Write;
 use teensy4_bsp as bsp;
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
-
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
@@ -21,7 +19,7 @@ fn main() -> ! {
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
     let mut buffer = [0; 256];
     loop {
         let bytes_read = reader.read(&mut buffer);
@@ -39,7 +37,7 @@ fn main() -> ! {
         }
 
         writeln!(writer, "Hello world! 3 + 2 = {}", 3 + 2).unwrap();
-        led.toggle().unwrap();
+        led.toggle();
         p.systick.delay(5000);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,74 +127,77 @@ pub use cortex_m_rt as rt;
 pub use imxrt_hal as hal;
 
 /// The LED in its final configuration
-pub type LED = hal::gpio::GPIO2IO03<hal::gpio::GPIO7, hal::gpio::Output>;
+pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
+
+use imxrt106x_iomuxc as iomuxc;
+use imxrt_iomuxc::consts::{U1, U2, U3, U4};
 
 /// Teensy pins that do not yet have a function
 ///
 /// Pin 13 can be used for several things; one common usage is for the on-board LED.
 pub struct Pins {
     /// Pin 0
-    pub p0: hal::iomuxc::gpio::GPIO_AD_B0_03<hal::iomuxc::Alt5>,
+    pub p0: iomuxc::ad_b0::AD_B0_03,
     /// Pin 1
-    pub p1: hal::iomuxc::gpio::GPIO_AD_B0_02<hal::iomuxc::Alt5>,
+    pub p1: iomuxc::ad_b0::AD_B0_02,
     /// Pin 2
-    pub p2: hal::iomuxc::gpio::GPIO_EMC_04<hal::iomuxc::Alt5>,
+    pub p2: iomuxc::emc::EMC_04,
     /// Pin 3
-    pub p3: hal::iomuxc::gpio::GPIO_EMC_05<hal::iomuxc::Alt5>,
+    pub p3: iomuxc::emc::EMC_05,
     /// Pin 4
-    pub p4: hal::iomuxc::gpio::GPIO_EMC_06<hal::iomuxc::Alt5>,
+    pub p4: iomuxc::emc::EMC_06,
     /// Pin 5
-    pub p5: hal::iomuxc::gpio::GPIO_EMC_08<hal::iomuxc::Alt5>,
+    pub p5: iomuxc::emc::EMC_08,
     /// Pin 6
-    pub p6: hal::iomuxc::gpio::GPIO_B0_10<hal::iomuxc::Alt5>,
+    pub p6: iomuxc::b0::B0_10,
     /// Pin 7
-    pub p7: hal::iomuxc::gpio::GPIO_B1_01<hal::iomuxc::Alt5>,
+    pub p7: iomuxc::b1::B1_01,
     /// Pin 8
-    pub p8: hal::iomuxc::gpio::GPIO_B1_00<hal::iomuxc::Alt5>,
+    pub p8: iomuxc::b1::B1_00,
     /// Pin 9
-    pub p9: hal::iomuxc::gpio::GPIO_B0_11<hal::iomuxc::Alt5>,
+    pub p9: iomuxc::b0::B0_11,
     /// Pin 10
-    pub p10: hal::iomuxc::gpio::GPIO_B0_00<hal::iomuxc::Alt5>,
+    pub p10: iomuxc::b0::B0_00,
     /// Pin 11
-    pub p11: hal::iomuxc::gpio::GPIO_B0_02<hal::iomuxc::Alt5>,
+    pub p11: iomuxc::b0::B0_02,
     /// Pin 12
-    pub p12: hal::iomuxc::gpio::GPIO_B0_01<hal::iomuxc::Alt5>,
+    pub p12: iomuxc::b0::B0_01,
     /// Pin 13
-    pub p13: hal::iomuxc::gpio::GPIO_B0_03<hal::iomuxc::Alt5>,
+    pub p13: iomuxc::b0::B0_03,
     /// Pin 14
-    pub p14: hal::iomuxc::gpio::GPIO_AD_B1_02<hal::iomuxc::Alt5>,
+    pub p14: iomuxc::ad_b1::AD_B1_02,
     /// Pin 15
-    pub p15: hal::iomuxc::gpio::GPIO_AD_B1_03<hal::iomuxc::Alt5>,
+    pub p15: iomuxc::ad_b1::AD_B1_03,
     /// Pin 16
-    pub p16: hal::iomuxc::gpio::GPIO_AD_B1_07<hal::iomuxc::Alt5>,
+    pub p16: iomuxc::ad_b1::AD_B1_07,
     /// Pin 17
-    pub p17: hal::iomuxc::gpio::GPIO_AD_B1_06<hal::iomuxc::Alt5>,
+    pub p17: iomuxc::ad_b1::AD_B1_06,
     /// Pin 18
-    pub p18: hal::iomuxc::gpio::GPIO_AD_B1_01<hal::iomuxc::Alt5>,
+    pub p18: iomuxc::ad_b1::AD_B1_01,
     /// Pin 19
-    pub p19: hal::iomuxc::gpio::GPIO_AD_B1_00<hal::iomuxc::Alt5>,
+    pub p19: iomuxc::ad_b1::AD_B1_00,
     /// Pin 20
-    pub p20: hal::iomuxc::gpio::GPIO_AD_B1_10<hal::iomuxc::Alt5>,
+    pub p20: iomuxc::ad_b1::AD_B1_10,
     /// Pin 21
-    pub p21: hal::iomuxc::gpio::GPIO_AD_B1_11<hal::iomuxc::Alt5>,
+    pub p21: iomuxc::ad_b1::AD_B1_11,
     /// Pin 22
-    pub p22: hal::iomuxc::gpio::GPIO_AD_B1_08<hal::iomuxc::Alt5>,
+    pub p22: iomuxc::ad_b1::AD_B1_08,
     /// Pin 23
-    pub p23: hal::iomuxc::gpio::GPIO_AD_B1_09<hal::iomuxc::Alt5>,
+    pub p23: iomuxc::ad_b1::AD_B1_09,
     /// Pin 24
-    pub p24: hal::iomuxc::gpio::GPIO_AD_B0_12<hal::iomuxc::Alt5>,
+    pub p24: iomuxc::ad_b0::AD_B0_12,
     /// Pin 25
-    pub p25: hal::iomuxc::gpio::GPIO_AD_B0_13<hal::iomuxc::Alt5>,
+    pub p25: iomuxc::ad_b0::AD_B0_13,
     /// Pin 28
-    pub p28: hal::iomuxc::gpio::GPIO_EMC_32<hal::iomuxc::Alt5>,
+    pub p28: iomuxc::emc::EMC_32,
     /// Pin 29
-    pub p29: hal::iomuxc::gpio::GPIO_EMC_31<hal::iomuxc::Alt5>,
+    pub p29: iomuxc::emc::EMC_31,
     /// Pin 33
-    pub p33: hal::iomuxc::gpio::GPIO_EMC_07<hal::iomuxc::Alt5>,
+    pub p33: iomuxc::emc::EMC_07,
     /// Pin 36
-    pub p36: hal::iomuxc::gpio::GPIO_SD_B0_01<hal::iomuxc::Alt5>,
+    pub p36: iomuxc::sd_b0::SD_B0_01,
     /// Pin 37
-    pub p37: hal::iomuxc::gpio::GPIO_SD_B0_00<hal::iomuxc::Alt5>,
+    pub p37: iomuxc::sd_b0::SD_B0_00,
 }
 
 /// All peripherals available on the Teensy4
@@ -217,13 +220,13 @@ pub struct Peripherals {
     /// DCDC converters
     pub dcdc: hal::dcdc::DCDC,
     /// PWM1 controller
-    pub pwm1: hal::pwm::Unclocked<hal::pwm::module::_1>,
+    pub pwm1: hal::pwm::Unclocked<U1>,
     /// PWM2 controller
-    pub pwm2: hal::pwm::Unclocked<hal::pwm::module::_2>,
+    pub pwm2: hal::pwm::Unclocked<U2>,
     /// PWM3 controller
-    pub pwm3: hal::pwm::Unclocked<hal::pwm::module::_3>,
+    pub pwm3: hal::pwm::Unclocked<U3>,
     /// PWM4 controller
-    pub pwm4: hal::pwm::Unclocked<hal::pwm::module::_4>,
+    pub pwm4: hal::pwm::Unclocked<U4>,
     /// Teensy pins
     pub pins: Pins,
     /// Unclocked I2C peripherals
@@ -232,8 +235,6 @@ pub struct Peripherals {
     pub spi: hal::spi::Unclocked,
     /// Unclocked UART peripherals
     pub uart: hal::uart::Unclocked,
-    /// General purpose registers, used when configuring GPIO pins.
-    pub gpr: hal::iomuxc::GPR,
     /// General purpose timer 1
     pub gpt1: hal::gpt::Unclocked,
     /// General purpose timer 2
@@ -294,42 +295,41 @@ impl Peripherals {
             pwm3: p.pwm3,
             pwm4: p.pwm4,
             pins: Pins {
-                p0: p.iomuxc.gpio_ad_b0_03,
-                p1: p.iomuxc.gpio_ad_b0_02,
-                p2: p.iomuxc.gpio_emc_04,
-                p3: p.iomuxc.gpio_emc_05,
-                p4: p.iomuxc.gpio_emc_06,
-                p5: p.iomuxc.gpio_emc_08,
-                p6: p.iomuxc.gpio_b0_10,
-                p7: p.iomuxc.gpio_b1_01,
-                p8: p.iomuxc.gpio_b1_00,
-                p9: p.iomuxc.gpio_b0_11,
-                p10: p.iomuxc.gpio_b0_00,
-                p11: p.iomuxc.gpio_b0_02,
-                p12: p.iomuxc.gpio_b0_01,
-                p13: p.iomuxc.gpio_b0_03,
-                p14: p.iomuxc.gpio_ad_b1_02,
-                p15: p.iomuxc.gpio_ad_b1_03,
-                p16: p.iomuxc.gpio_ad_b1_07,
-                p17: p.iomuxc.gpio_ad_b1_06,
-                p18: p.iomuxc.gpio_ad_b1_01,
-                p19: p.iomuxc.gpio_ad_b1_00,
-                p20: p.iomuxc.gpio_ad_b1_10,
-                p21: p.iomuxc.gpio_ad_b1_11,
-                p22: p.iomuxc.gpio_ad_b1_08,
-                p23: p.iomuxc.gpio_ad_b1_09,
-                p24: p.iomuxc.gpio_ad_b0_12,
-                p25: p.iomuxc.gpio_ad_b0_13,
-                p28: p.iomuxc.gpio_emc_32,
-                p29: p.iomuxc.gpio_emc_31,
-                p33: p.iomuxc.gpio_emc_07,
-                p36: p.iomuxc.gpio_sd_b0_01,
-                p37: p.iomuxc.gpio_sd_b0_00,
+                p0: p.iomuxc.ad_b0.p03,
+                p1: p.iomuxc.ad_b0.p02,
+                p2: p.iomuxc.emc.p04,
+                p3: p.iomuxc.emc.p05,
+                p4: p.iomuxc.emc.p06,
+                p5: p.iomuxc.emc.p08,
+                p6: p.iomuxc.b0.p10,
+                p7: p.iomuxc.b1.p01,
+                p8: p.iomuxc.b1.p00,
+                p9: p.iomuxc.b0.p11,
+                p10: p.iomuxc.b0.p00,
+                p11: p.iomuxc.b0.p02,
+                p12: p.iomuxc.b0.p01,
+                p13: p.iomuxc.b0.p03,
+                p14: p.iomuxc.ad_b1.p02,
+                p15: p.iomuxc.ad_b1.p03,
+                p16: p.iomuxc.ad_b1.p07,
+                p17: p.iomuxc.ad_b1.p06,
+                p18: p.iomuxc.ad_b1.p01,
+                p19: p.iomuxc.ad_b1.p00,
+                p20: p.iomuxc.ad_b1.p10,
+                p21: p.iomuxc.ad_b1.p11,
+                p22: p.iomuxc.ad_b1.p08,
+                p23: p.iomuxc.ad_b1.p09,
+                p24: p.iomuxc.ad_b0.p12,
+                p25: p.iomuxc.ad_b0.p13,
+                p28: p.iomuxc.emc.p32,
+                p29: p.iomuxc.emc.p31,
+                p33: p.iomuxc.emc.p07,
+                p36: p.iomuxc.sd_b0.p01,
+                p37: p.iomuxc.sd_b0.p00,
             },
             i2c: p.i2c,
             spi: p.spi,
             uart: p.uart,
-            gpr: p.iomuxc.gpr,
             gpt1: p.gpt1,
             gpt2: p.gpt2,
             dma: p.dma,
@@ -343,9 +343,10 @@ impl Peripherals {
 ///
 /// Returns a GPIO that's physically tied to the LED. Use the returned handle
 /// to drive the LED.
-pub fn configure_led<A>(gpr: &mut hal::iomuxc::GPR, pad: hal::iomuxc::gpio::GPIO_B0_03<A>) -> LED {
-    use hal::gpio::IntoGpio;
-    pad.alt5().into_gpio().fast(gpr).output()
+pub fn configure_led(pad: iomuxc::b0::B0_03) -> LED {
+    let mut led = hal::gpio::GPIO::new(pad);
+    led.set_fast(true);
+    led.output()
 }
 
 /// TODO(mciantyre) define a better yield

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@ pub use imxrt_hal as hal;
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
 
-use imxrt106x_iomuxc as iomuxc;
-use imxrt_iomuxc::consts::{U1, U2, U3, U4};
+use hal::iomuxc as iomuxc;
+use iomuxc::consts::{U1, U2, U3, U4};
 
 /// Teensy pins that do not yet have a function
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub use imxrt_hal as hal;
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
 
-use hal::iomuxc as iomuxc;
+use hal::iomuxc;
 use iomuxc::consts::{U1, U2, U3, U4};
 
 /// Teensy pins that do not yet have a function


### PR DESCRIPTION
The PR integrates the new i.MX RT IOMUXC driver API through the BSP's examples. This is a breaking change which will coincide with the 0.4 release of the HAL. The PR serves as a reference for how user code might change. See imxrt-rs/imxrt-rs#73 for more details.

- [ ] Remove the git dependency on the HAL
- [x] Finish, or remove, RTIC-associated changes in `Makefile`
- [ ] Update the template