### PR TITLE
Expose USB writer

### DIFF
--- a/examples/usb_writer.rs
+++ b/examples/usb_writer.rs
@@ -1,0 +1,45 @@
+//! Demonstrates our ability to write over USB, and read
+//! USB serial messages from a USB host.
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use bsp::rt;
+use core::fmt::Write;
+use teensy4_bsp as bsp;
+
+use embedded_hal::digital::v2::ToggleableOutputPin;
+
+#[rt::entry]
+fn main() -> ! {
+    let mut p = bsp::Peripherals::take().unwrap();
+    // Split the USB stack into read / write halves
+    let (mut reader, mut writer) = p.usb.split();
+    p.systick.delay(2000);
+    p.ccm
+        .pll1
+        .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
+    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut buffer = [0; 256];
+    loop {
+        let bytes_read = reader.read(&mut buffer);
+        if bytes_read > 0 {
+            let bytes = &buffer[..bytes_read];
+            match core::str::from_utf8(bytes) {
+                Ok(msg) => writeln!(writer, "Received message: {} ({:?})", msg, bytes).unwrap(),
+                Err(e) => writeln!(
+                    writer,
+                    "Read {} bytes, but could not interpret message {:?}: {:?}",
+                    bytes_read, bytes, e
+                )
+                .unwrap(),
+            }
+        }
+
+        writeln!(writer, "Hello world! 3 + 2 = {}", 3 + 2).unwrap();
+        led.toggle().unwrap();
+        p.systick.delay(5000);
+    }
+}

--- a/teensy4-usb-sys/src/lib.rs
+++ b/teensy4-usb-sys/src/lib.rs
@@ -59,14 +59,11 @@ extern "C" {
     fn usb_serial_read(buffer: *mut u8, size: u32) -> i32;
 }
 
-/// Writes the buffer of data to the USB host
-///
-/// TODO error handling, return the number of bytes written, etc.
-pub fn serial_write<B: AsRef<[u8]>>(buffer: B) {
+/// Writes the buffer of data to the USB host, returning the number
+/// of bytes written
+pub fn serial_write<B: AsRef<[u8]>>(buffer: B) -> u32 {
     let buffer = buffer.as_ref();
-    unsafe {
-        usb_serial_write(buffer.as_ptr(), buffer.len() as u32);
-    }
+    unsafe { usb_serial_write(buffer.as_ptr(), buffer.len() as u32) as u32 }
 }
 
 /// Reads a buffer of data from the USB serial endpoint


### PR DESCRIPTION
The PR lets users `split()` the USB handle. When you split the handle, you get back a USB reader and USB writer. You can use the writer to send formatted / raw data back to the USB serial host.

See the new `usb_writer.rs` example for more information.

```rust
use core::fmt::Write;

let mut p = bsp::Peripherals::take().unwrap();
let (mut reader, mut writer) = p.usb.split();
writeln!(writer, "Hello world! 3 + 2 = {}", 3 + 2).unwrap();
```