### PR TITLE
Prototype Teensy 4.1 support

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -3,6 +3,7 @@ status = [
     "doc",
     "format",
     "precompiled",
-    "template"
+    "template",
+    "test"
 ]
 delete_merged_branches = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
           command: fmt
           args: --verbose --all -- --check
   
-  # Since we don't have any automated tests right now, we can use a clippy
-  # run to check the build and surface linting errors.
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -45,3 +43,14 @@ jobs:
         run: INSTALL_DEPS=0 make libt4boot
       - name: Build USB stack
         run: INSTALL_DEPS=0 make libt4usb
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - name: Run unit and documentation tests
+        run: INSTALL_DEPS=0 make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ teensy4-fcb = { path = "teensy4-fcb" }
 [dependencies.imxrt-hal]
 version = "0.3.0"
 git = "https://github.com/imxrt-rs/imxrt-rs.git"
-branch = "iomuxc-integration"
+rev = "1815db6"
 features = ["imxrt1062", "rt"]
 
 # Tied to "systick" feature, since
@@ -106,9 +106,3 @@ opt-level = 0
 [patch.crates-io.cortex-m-rt]
 path = "cortex-m-rt-patch"
 
-# Patch `imxrt-hal` so that we may access the `hal::Peripherals::steal`
-# constructor. This patch should be removed once a new version of
-# `imxrt-hal` is published with the new constructor.
-[patch.crates-io.imxrt-hal]
-git = "https://github.com/imxrt-rs/imxrt-rs"
-rev = "0305aed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,14 @@ teensy4-fcb = { path = "teensy4-fcb" }
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
+path = "../imxrt/imxrt/imxrt-hal"
 features = ["imxrt1062", "rt"]
+
+[dependencies.imxrt-iomuxc]
+path = "../imxrt/iomuxc"
+
+[dependencies.imxrt106x-iomuxc]
+path = "../imxrt/iomuxc/imxrt106x-iomuxc"
 
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
@@ -48,14 +55,17 @@ panic-halt = "0.2.0"
 name = "rtic_led"
 path = "examples/rtic_led.rs"
 required-features = ["rtic"]
+
 [[example]]
 name = "rtic_blink"
 path = "examples/rtic_blink.rs"
 required-features = ["rtic"]
+
 [[example]]
 name = "rtic_uart_log"
 path = "examples/rtic_uart_log.rs"
 required-features = ["rtic"]
+
 [[example]]
 name = "rtic_dma_uart_log"
 path = "examples/rtic_dma_uart_log.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,6 @@ opt-level = 0
 [patch.crates-io.cortex-m-rt]
 path = "cortex-m-rt-patch"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,8 @@ cortex-m-rt = "0.6.12" # Note: not the 'real' cortex-m-rt
 teensy4-fcb = { path = "teensy4-fcb" }
 
 [dependencies.imxrt-hal]
-version = "0.3.0"
-git = "https://github.com/imxrt-rs/imxrt-rs.git"
-rev = "1815db6"
+version = "0.4.0"
 features = ["imxrt1062", "rt"]
-
-[dev-dependencies.imxrt-uart-log]
-git = "https://github.com/imxrt-rs/imxrt-uart-log.git"
 
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
@@ -46,6 +41,7 @@ optional = true
 cortex-m-rtic = "0.5.3"
 embedded-hal = "0.2.4"
 heapless = "0.5.5"
+imxrt-uart-log = "0.2.0"
 log = "0.4.8"
 nb = "0.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ teensy4-fcb = { path = "teensy4-fcb" }
 
 [dependencies.imxrt-hal]
 version = "0.3.0"
-path = "../imxrt/imxrt/imxrt-hal"
+git = "https://github.com/imxrt-rs/imxrt-rs.git"
+branch = "iomuxc-integration"
 features = ["imxrt1062", "rt"]
 
 # Tied to "systick" feature, since

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,6 @@ version = "0.3.0"
 path = "../imxrt/imxrt/imxrt-hal"
 features = ["imxrt1062", "rt"]
 
-[dependencies.imxrt-iomuxc]
-path = "../imxrt/iomuxc"
-
-[dependencies.imxrt106x-iomuxc]
-path = "../imxrt/iomuxc/imxrt106x-iomuxc"
-
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
 [dependencies.embedded-hal]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ git = "https://github.com/imxrt-rs/imxrt-rs.git"
 rev = "1815db6"
 features = ["imxrt1062", "rt"]
 
+[dev-dependencies.imxrt-uart-log]
+git = "https://github.com/imxrt-rs/imxrt-uart-log.git"
+
 # Tied to "systick" feature, since
 # SysTick implements a blocking delay trait
 [dependencies.embedded-hal]
@@ -42,7 +45,6 @@ cortex-m-rtic = "0.5.3"
 embedded-hal = "0.2.4"
 heapless = "0.5.5"
 log = "0.4.8"
-imxrt-uart-log = "0.1.0"
 nb = "0.1.2"
 panic-halt = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ Part of the teensy4-rs project.
 [dependencies]
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.12" # Note: not the 'real' cortex-m-rt
+
+[target.thumbv7em-none-eabihf.dependencies]
 teensy4-fcb = { path = "teensy4-fcb" }
 
 [dependencies.imxrt-hal]
@@ -40,12 +42,14 @@ optional = true
 path = "teensy4-usb-sys"
 optional = true
 
-[dev-dependencies]
+[target.thumbv7em-none-eabihf.dev-dependencies]
 cortex-m-rtic = "0.5.3"
 embedded-hal = "0.2.4"
 heapless = "0.5.5"
 log = "0.4.8"
 nb = "0.1.2"
+
+[dev-dependencies]
 panic-halt = "0.2.0"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ systick = ["embedded-hal"]
 # NOTE: When using this feature along with the `rtic` crate the
 # default features must first be disabled in order to avoid a
 # duplicate definition of `SysTick`.
-rtic = []
+rtic = ["imxrt-hal/rtic"]
 
 # Don't optimize build dependencies, like proc macros.
 # Helps with build times.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifneq ($(INSTALL_DEPS),0)
 # Ensure the thumbv7em-none-eabihf component is installed
 THUMBV7EM_NONE_EABIHF_INSTALLED := $(shell $(RUSTUP) component list | grep 'rust-std-thumbv7em-none-eabihf.*(installed)' > /dev/null; echo $$?)
 ifeq ($(THUMBV7EM_NONE_EABIHF_INSTALLED), 1)
-  $(shell $(RUSTUP) component add thumbv7em-none-eabihf)
+  $(shell $(RUSTUP) target add thumbv7em-none-eabihf)
 endif
 
 # Ensure llvm-tools-preview is installed
@@ -35,8 +35,8 @@ endif
 endif # INSTALL_DEPS != 0
 
 TARGET_EXAMPLES := target/thumbv7em-none-eabihf/release/examples
-EXAMPLES := $(shell ls examples | grep -v rtic | xargs basename | cut -f 1 -d .)
-RTIC_EXAMPLES := $(shell ls examples | grep rtic | xargs basename | cut -f 1 -d .)
+EXAMPLES := $(shell ls -1 examples | grep -v rtic | cut -f 1 -d .)
+RTIC_EXAMPLES := $(shell ls -1 examples | grep rtic | cut -f 1 -d .)
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,12 @@ libt4usb:
 clean:
 	@cargo clean
 
+# Skipping the USB feature testing
+#
+# We can't link the t4usb library when testing on our host, since
+# it's compiled for a different architecture. The documentation tests
+# still work.
 .PHONY: test
 test:
-	@cargo +nightly test --lib --tests --target $(HOST)
-	@cargo +nightly test --doc --target $(HOST)
+	@cargo +nightly test --lib --tests --target $(HOST) --no-default-features --features systick
+	@cargo +nightly test --doc --target $(HOST) --all-features

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CARGO ?= cargo
 TEENSY_LOADER ?= teensy_loader_cli
 MODE ?= --release
 INSTALL_DEPS ?= 1
+HOST ?= $(shell rustc --version --verbose | grep host | cut -d ' ' -f 2)
 
 ifneq ($(INSTALL_DEPS),0)
 # Ensure the thumbv7em-none-eabihf component is installed
@@ -78,3 +79,8 @@ libt4usb:
 .PHONY: clean
 clean:
 	@cargo clean
+
+.PHONY: test
+test:
+	@cargo +nightly test --lib --tests --target $(HOST)
+	@cargo +nightly test --doc --target $(HOST)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ endif # INSTALL_DEPS != 0
 
 TARGET_EXAMPLES := target/thumbv7em-none-eabihf/release/examples
 EXAMPLES := $(shell ls examples | xargs basename | cut -f 1 -d .)
+RTIC_EXAMPLES := $(shell ls examples | grep rtic | xargs basename | cut -f 1 -d .)
 
 .PHONY: all
 all:
@@ -42,6 +43,14 @@ all:
 	@for example in $(EXAMPLES);\
 		do cargo objcopy $(MODE) --example $$example \
 			-- -O ihex $(TARGET_EXAMPLES)/$$example.hex;\
+		done
+
+# Build all RTIC-related examples
+.PHONY: rtic
+rtic:
+	@for example in $(RTIC_EXAMPLES);\
+		do cargo build $(MODE) --example $$example \
+			--no-default-features --features=rtic;\
 		done
 
 .PHONY: example_%

--- a/examples/dma_memcpy.rs
+++ b/examples/dma_memcpy.rs
@@ -34,8 +34,9 @@ const NUMBER_OF_ELEMENTS: Element = (BUFFER_SIZE - 7) as Element;
 #[entry]
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
-    peripherals.usb.init(Default::default());
-    peripherals.systick.delay(5_000);
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    bsp::usb_init(&systick, Default::default()).unwrap();
+    systick.delay(5_000);
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
     let channel = dma_channels[13].take().unwrap();
@@ -141,6 +142,6 @@ fn main() -> ! {
         tx_buffer.clear();
 
         start += 1;
-        peripherals.systick.delay(5_000);
+        systick.delay(5_000);
     }
 }

--- a/examples/dma_memcpy.rs
+++ b/examples/dma_memcpy.rs
@@ -35,7 +35,7 @@ const NUMBER_OF_ELEMENTS: Element = (BUFFER_SIZE - 7) as Element;
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     systick.delay(5_000);
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -80,7 +80,7 @@ static TX_BUFFER: Mutex<RefCell<Option<TxBuffer>>> = Mutex::new(RefCell::new(Non
 static RX_BUFFER: Mutex<RefCell<Option<RxBuffer>>> = Mutex::new(RefCell::new(None));
 
 type SpiDma =
-    dma::Peripheral<bsp::hal::spi::SPI<imxrt_iomuxc::consts::U4>, u16, TxBuffer, RxBuffer>;
+    dma::Peripheral<bsp::hal::spi::SPI<bsp::hal::iomuxc::consts::U4>, u16, TxBuffer, RxBuffer>;
 
 // TODO types should be Send
 static mut SPI_DMA: Option<SpiDma> = None;
@@ -158,7 +158,7 @@ fn rx_buffer_mut<F: FnOnce(&mut RxBuffer) -> R, R>(act: F) -> Option<R> {
 }
 
 // Pin 20
-type HardwareFlag = bsp::hal::gpio::GPIO<imxrt106x_iomuxc::ad_b1::AD_B1_10, bsp::hal::gpio::Output>;
+type HardwareFlag = bsp::hal::gpio::GPIO<bsp::hal::iomuxc::ad_b1::AD_B1_10, bsp::hal::gpio::Output>;
 static mut HARDWARE_FLAG: Option<HardwareFlag> = None;
 
 #[entry]

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -165,7 +165,7 @@ static mut HARDWARE_FLAG: Option<HardwareFlag> = None;
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     let pins = bsp::t40::pins(peripherals.iomuxc);
 
     peripherals.ccm.pll1.set_arm_clock(

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -80,7 +80,7 @@ static TX_BUFFER: Mutex<RefCell<Option<TxBuffer>>> = Mutex::new(RefCell::new(Non
 static RX_BUFFER: Mutex<RefCell<Option<RxBuffer>>> = Mutex::new(RefCell::new(None));
 
 type SpiDma =
-    dma::Peripheral<bsp::hal::spi::SPI<bsp::hal::spi::module::_4>, u16, TxBuffer, RxBuffer>;
+    dma::Peripheral<bsp::hal::spi::SPI<imxrt_iomuxc::consts::U4>, u16, TxBuffer, RxBuffer>;
 
 // TODO types should be Send
 static mut SPI_DMA: Option<SpiDma> = None;
@@ -158,7 +158,7 @@ fn rx_buffer_mut<F: FnOnce(&mut RxBuffer) -> R, R>(act: F) -> Option<R> {
 }
 
 // Pin 20
-type HardwareFlag = bsp::hal::gpio::GPIO1IO26<bsp::hal::gpio::GPIO1, bsp::hal::gpio::Output>;
+type HardwareFlag = bsp::hal::gpio::GPIO<imxrt106x_iomuxc::ad_b1::AD_B1_10, bsp::hal::gpio::Output>;
 static mut HARDWARE_FLAG: Option<HardwareFlag> = None;
 
 #[entry]
@@ -174,8 +174,7 @@ fn main() -> ! {
 
     unsafe {
         let p20 = peripherals.pins.p20;
-        use bsp::hal::gpio::IntoGpio;
-        HARDWARE_FLAG = Some(p20.alt5().into_gpio().output());
+        HARDWARE_FLAG = Some(bsp::hal::gpio::GPIO::new(p20).output());
     }
 
     //
@@ -193,11 +192,11 @@ fn main() -> ! {
 
     log::info!("Constructing SPI4 peripheral...");
     let mut spi4 = spi4_builder.build(
-        peripherals.pins.p11.alt3(),
-        peripherals.pins.p12.alt3(),
-        peripherals.pins.p13.alt3(),
+        peripherals.pins.p11,
+        peripherals.pins.p12,
+        peripherals.pins.p13,
     );
-    spi4.enable_chip_select_0(peripherals.pins.p10.alt3());
+    spi4.enable_chip_select_0(peripherals.pins.p10);
 
     match spi4.set_clock_speed(bsp::hal::spi::ClockSpeed(SPI_BAUD_RATE_HZ)) {
         Ok(()) => {

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -220,20 +220,14 @@ fn main() -> ! {
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
     let tx_channel = dma_channels[9].take().unwrap();
-    let rx_channel = dma_channels[25].take().unwrap();
-    let rx_config = dma::ConfigBuilder::new()
-        .interrupt_on_completion(true)
-        .build();
+    let mut rx_channel = dma_channels[25].take().unwrap();
+    rx_channel.set_interrupt_on_completion(true);
 
     // We only want to interrupt when the receive completes. When
     // the receive completes, we know that we're also done transferring
     // data.
     let spi = unsafe {
-        SPI_DMA = Some(dma::bidirectional_u16(
-            spi4,
-            (tx_channel, dma::ConfigBuilder::new().build()),
-            (rx_channel, rx_config),
-        ));
+        SPI_DMA = Some(dma::bidirectional_u16(spi4, tx_channel, rx_channel));
         cortex_m::peripheral::NVIC::unmask(interrupt::DMA9_DMA25);
         SPI_DMA.as_mut().unwrap()
     };

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -92,18 +92,15 @@ fn main() -> ! {
         .unwrap();
 
     let mut dma_channels = peripherals.dma.clock(&mut peripherals.ccm.handle);
-    let tx_channel = dma_channels[7].take().unwrap();
-    let rx_channel = dma_channels[23].take().unwrap();
+    let mut tx_channel = dma_channels[7].take().unwrap();
+    let mut rx_channel = dma_channels[23].take().unwrap();
 
-    let config = bsp::hal::dma::ConfigBuilder::new()
-        .interrupt_on_completion(true)
-        .build();
+    tx_channel.set_interrupt_on_completion(true);
+    rx_channel.set_interrupt_on_completion(true);
 
     let dma_uart = unsafe {
         DMA_PERIPHERAL = Some(bsp::hal::dma::Peripheral::new_bidirectional(
-            uart,
-            (tx_channel, config),
-            (rx_channel, config),
+            uart, tx_channel, rx_channel,
         ));
         cortex_m::peripheral::NVIC::unmask(interrupt::DMA7_DMA23);
         DMA_PERIPHERAL.as_mut().unwrap()

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -80,7 +80,7 @@ unsafe fn DMA7_DMA23() {
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     let pins = bsp::t40::pins(peripherals.iomuxc);
 
     systick.delay(5_000);

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -40,7 +40,7 @@ static TX_BUFFER: Mutex<RefCell<Option<TxBuffer>>> = Mutex::new(RefCell::new(Non
 static RX_BUFFER: Mutex<RefCell<Option<RxBuffer>>> = Mutex::new(RefCell::new(None));
 
 type DmaUart = bsp::hal::dma::Peripheral<
-    bsp::hal::uart::UART<imxrt_iomuxc::consts::U2>,
+    bsp::hal::uart::UART<bsp::hal::iomuxc::consts::U2>,
     u8,
     TxBuffer,
     RxBuffer,

--- a/examples/gpt.rs
+++ b/examples/gpt.rs
@@ -11,7 +11,6 @@ extern crate panic_halt;
 use bsp::hal::gpt;
 use bsp::interrupt;
 use bsp::rt::{entry, interrupt};
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use teensy4_bsp as bsp;
 
 use core::time::Duration;
@@ -53,13 +52,13 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
     }
 
-    let mut led = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut led = bsp::configure_led(periphs.pins.p13);
     loop {
         let gpt1 = unsafe { TIMER.as_mut().unwrap() };
         gpt1.set_enable(false);
         gpt1.set_output_compare_duration(OCR, Duration::from_millis(400));
         gpt1.set_enable(true);
         cortex_m::asm::wfi();
-        led.toggle().unwrap();
+        led.toggle();
     }
 }

--- a/examples/gpt.rs
+++ b/examples/gpt.rs
@@ -28,6 +28,7 @@ unsafe fn GPT1() {
 #[entry]
 fn main() -> ! {
     let mut periphs = bsp::Peripherals::take().unwrap();
+    let pins = bsp::t40::pins(periphs.iomuxc);
 
     let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
         bsp::hal::ccm::PLL1::ARM_HZ,
@@ -52,7 +53,7 @@ fn main() -> ! {
         cortex_m::peripheral::NVIC::unmask(interrupt::GPT1);
     }
 
-    let mut led = bsp::configure_led(periphs.pins.p13);
+    let mut led = bsp::configure_led(pins.p13);
     loop {
         let gpt1 = unsafe { TIMER.as_mut().unwrap() };
         gpt1.set_enable(false);

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     let pins = bsp::t40::pins(peripherals.iomuxc);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     systick.delay(5000);
 
     log::info!("Enabling I2C clocks...");

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
     );
 
     log::info!("Constructing I2C3 instance on pins 16 and 17...");
-    let mut i2c3 = i2c3_builder.build(peripherals.pins.p16.alt1(), peripherals.pins.p17.alt1());
+    let mut i2c3 = i2c3_builder.build(peripherals.pins.p16, peripherals.pins.p17);
 
     if let Err(err) = i2c3.set_bus_idle_timeout(core::time::Duration::from_micros(200)) {
         log::warn!("Error when setting bus idle timeout: {:?}", err);
@@ -71,11 +71,13 @@ fn main() -> ! {
     }
 
     log::info!("Starting I/O loop...");
+    let mut counter = 0;
     loop {
         peripherals.systick.delay(1000);
         log::info!("Querying WHO_AM_I...");
+        counter += 1;
         match who_am_i(&mut i2c3) {
-            Ok(who) => log::info!("Received 0x{:X} for WHO_AM_I", who),
+            Ok(who) => log::info!("Received 0x{:X} for WHO_AM_I (iter = {})", who, counter),
             Err(err) => {
                 log::warn!("Error reading WHO_AM_I: {:?}", err);
                 continue;

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -43,8 +43,10 @@ where
 #[bsp::rt::entry]
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
-    peripherals.usb.init(Default::default());
-    peripherals.systick.delay(5000);
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    let pins = bsp::t40::pins(peripherals.iomuxc);
+    bsp::usb_init(&systick, Default::default()).unwrap();
+    systick.delay(5000);
 
     log::info!("Enabling I2C clocks...");
     let (_, _, i2c3_builder, _) = peripherals.i2c.clock(
@@ -54,7 +56,7 @@ fn main() -> ! {
     );
 
     log::info!("Constructing I2C3 instance on pins 16 and 17...");
-    let mut i2c3 = i2c3_builder.build(peripherals.pins.p16, peripherals.pins.p17);
+    let mut i2c3 = i2c3_builder.build(pins.p16, pins.p17);
 
     if let Err(err) = i2c3.set_bus_idle_timeout(core::time::Duration::from_micros(200)) {
         log::warn!("Error when setting bus idle timeout: {:?}", err);
@@ -73,7 +75,7 @@ fn main() -> ! {
     log::info!("Starting I/O loop...");
     let mut counter = 0;
     loop {
-        peripherals.systick.delay(1000);
+        systick.delay(1000);
         log::info!("Querying WHO_AM_I...");
         counter += 1;
         match who_am_i(&mut i2c3) {

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -16,7 +16,8 @@ use embedded_hal::digital::v2::OutputPin;
 #[entry]
 fn main() -> ! {
     let peripherals = bsp::Peripherals::take().unwrap();
-    let mut led = bsp::configure_led(peripherals.pins.p13);
+    let pins = bsp::t40::pins(peripherals.iomuxc);
+    let mut led = bsp::configure_led(pins.p13);
 
     loop {
         led.set_high().unwrap();

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -15,8 +15,8 @@ use embedded_hal::digital::v2::OutputPin;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = bsp::Peripherals::take().unwrap();
-    let mut led = bsp::configure_led(&mut peripherals.gpr, peripherals.pins.p13);
+    let peripherals = bsp::Peripherals::take().unwrap();
+    let mut led = bsp::configure_led(peripherals.pins.p13);
 
     loop {
         led.set_high().unwrap();

--- a/examples/pit.rs
+++ b/examples/pit.rs
@@ -30,13 +30,15 @@ unsafe fn PIT() {
 #[entry]
 fn main() -> ! {
     let mut periphs = bsp::Peripherals::take().unwrap();
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    let pins = bsp::t40::pins(periphs.iomuxc);
     // When flashing a debug build, I'm finding that
     // the chip is likely to crash if we don't put this
     // delay here. I've narrowed it down to something
     // with the WFI in the loop, maybe...? If I instead
     // busy-loop on an atomic U32, I don't crash in debug
     // builds.
-    periphs.systick.delay(25);
+    systick.delay(25);
     let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
         bsp::hal::ccm::PLL1::ARM_HZ,
         &mut periphs.ccm.handle,
@@ -77,7 +79,7 @@ fn main() -> ! {
             .start(core::time::Duration::from_millis(250));
         cortex_m::peripheral::NVIC::unmask(interrupt::PIT);
     }
-    let mut led = bsp::configure_led(periphs.pins.p13);
+    let mut led = bsp::configure_led(pins.p13);
     loop {
         led.toggle();
         cortex_m::asm::wfi();

--- a/examples/pit.rs
+++ b/examples/pit.rs
@@ -13,7 +13,7 @@ extern crate panic_halt;
 use bsp::hal::pit;
 use bsp::interrupt;
 use bsp::rt::{entry, interrupt};
-use embedded_hal::{digital::v2::ToggleableOutputPin, timer::CountDown};
+use embedded_hal::timer::CountDown;
 use teensy4_bsp as bsp;
 
 static mut TIMER: Option<pit::PIT<pit::channel::_3>> = None;
@@ -77,9 +77,9 @@ fn main() -> ! {
             .start(core::time::Duration::from_millis(250));
         cortex_m::peripheral::NVIC::unmask(interrupt::PIT);
     }
-    let mut led = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut led = bsp::configure_led(periphs.pins.p13);
     loop {
-        led.toggle().unwrap();
+        led.toggle();
         cortex_m::asm::wfi();
     }
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     let pins = bsp::t40::pins(p.iomuxc);
     // Initialize the logging, so we can use it in the PWM loop below
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     // Delay is only to let a user set-up their USB serial connection...
     systick.delay(5000);
     // Set the core and IPG clock. The IPG clock frequency drives the PWM (sub)modules

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -47,8 +47,8 @@ fn main() -> ! {
         .sm2
         .outputs(
             &mut pwm2.handle,
-            p.pins.p6.alt2(),
-            p.pins.p9.alt2(),
+            p.pins.p6,
+            p.pins.p9,
             bsp::hal::pwm::Timing {
                 clock_select: bsp::hal::ccm::pwm::ClockSelect::IPG(ipg_hz),
                 prescalar: bsp::hal::ccm::pwm::Prescalar::PRSC_5,

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -29,16 +29,18 @@ fn percent(duty: u16) -> f32 {
 fn main() -> ! {
     // Prepare all the BSP peripherals
     let mut p = bsp::Peripherals::take().unwrap();
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    let pins = bsp::t40::pins(p.iomuxc);
     // Initialize the logging, so we can use it in the PWM loop below
-    p.usb.init(Default::default());
+    bsp::usb_init(&systick, Default::default()).unwrap();
     // Delay is only to let a user set-up their USB serial connection...
-    p.systick.delay(5000);
+    systick.delay(5000);
     // Set the core and IPG clock. The IPG clock frequency drives the PWM (sub)modules
     let (_, ipg_hz) =
         p.ccm
             .pll1
             .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    p.systick.delay(100);
+    systick.delay(100);
     // Enable the clocks for the PWM2 module
     let mut pwm2 = p.pwm2.clock(&mut p.ccm.handle);
     // Get the outputs from the PWM2 module, submodule 2.
@@ -47,8 +49,8 @@ fn main() -> ! {
         .sm2
         .outputs(
             &mut pwm2.handle,
-            p.pins.p6,
-            p.pins.p9,
+            pins.p6,
+            pins.p9,
             bsp::hal::pwm::Timing {
                 clock_select: bsp::hal::ccm::pwm::ClockSelect::IPG(ipg_hz),
                 prescalar: bsp::hal::ccm::pwm::Prescalar::PRSC_5,
@@ -71,15 +73,15 @@ fn main() -> ! {
         ctrl.enable(Channel::B);
         ctrl.set_duty(Channel::A, duty1);
         ctrl.set_duty(Channel::B, duty2);
-        p.systick.delay(200);
+        systick.delay(200);
 
         log::info!("Disabling 'B' PWM...");
         ctrl.disable(Channel::B);
-        p.systick.delay(200);
+        systick.delay(200);
 
         log::info!("Disabling 'A' PWM...");
         ctrl.disable(Channel::A);
-        p.systick.delay(400);
+        systick.delay(400);
 
         core::mem::swap(&mut duty1, &mut duty2);
     }

--- a/examples/rtic_blink.rs
+++ b/examples/rtic_blink.rs
@@ -53,8 +53,8 @@ const APP: () = {
 
         // Schedule the first blink.
         cx.schedule.blink(cx.start + PERIOD.cycles()).unwrap();
-
-        let mut led = bsp::configure_led(cx.device.pins.p13);
+        let pins = bsp::t40::pins(cx.device.iomuxc);
+        let mut led = bsp::configure_led(pins.p13);
         led.set_high().unwrap();
 
         init::LateResources { led }

--- a/examples/rtic_blink.rs
+++ b/examples/rtic_blink.rs
@@ -10,7 +10,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::OutputPin;
 use panic_halt as _;
 use rtic::cyccnt::U32Ext;
 use teensy4_bsp as bsp;
@@ -54,7 +54,7 @@ const APP: () = {
         // Schedule the first blink.
         cx.schedule.blink(cx.start + PERIOD.cycles()).unwrap();
 
-        let mut led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        let mut led = bsp::configure_led(cx.device.pins.p13);
         led.set_high().unwrap();
 
         init::LateResources { led }
@@ -62,7 +62,7 @@ const APP: () = {
 
     #[task(resources = [led], schedule = [blink])]
     fn blink(cx: blink::Context) {
-        cx.resources.led.toggle().unwrap();
+        cx.resources.led.toggle();
         // Schedule the following blink.
         cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();
     }

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -66,6 +66,8 @@ const APP: () = {
             &mut cx.device.dcdc,
         );
 
+        let pins = bsp::t40::pins(cx.device.iomuxc);
+
         // DMA setup.
         let mut dma_channels = cx.device.dma.clock(&mut cx.device.ccm.handle);
         let channel = dma_channels[7].take().unwrap();
@@ -76,10 +78,7 @@ const APP: () = {
             bsp::hal::ccm::uart::ClockSelect::OSC,
             bsp::hal::ccm::uart::PrescalarSelect::DIVIDE_1,
         );
-        let mut uart = uarts
-            .uart2
-            .init(cx.device.pins.p14, cx.device.pins.p15, BAUD)
-            .unwrap();
+        let mut uart = uarts.uart2.init(pins.p14, pins.p15, BAUD).unwrap();
         uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
         uart.set_rx_fifo(true);
         uart.set_receiver_interrupt(Some(0));
@@ -93,7 +92,7 @@ const APP: () = {
         let (q_tx, q_rx) = unsafe { Q.split() };
 
         // LED setup.
-        let mut led = bsp::configure_led(cx.device.pins.p13);
+        let mut led = bsp::configure_led(pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -41,7 +41,7 @@ type Producer = heapless::spsc::Producer<'static, Ty, Cap>;
 type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 
 // The UART receiver.
-type UartRx = bsp::hal::uart::Rx<imxrt_iomuxc::consts::U2>;
+type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -149,7 +149,7 @@ const APP: () = {
     #[task(binds = DMA7_DMA23, resources = [dma_interrupt_count])]
     fn dma7_dma23(cx: dma7_dma23::Context) {
         *cx.resources.dma_interrupt_count += 1;
-        imxrt_uart_log::dma::poll()
+        imxrt_uart_log::dma::poll();
     }
 
     // RTIC requires that unused interrupts are declared in an extern block when

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -22,7 +22,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::serial::Read;
 use heapless::consts::U256;
 use panic_halt as _;
@@ -41,7 +41,7 @@ type Producer = heapless::spsc::Producer<'static, Ty, Cap>;
 type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 
 // The UART receiver.
-type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::uart::module::_2>;
+type UartRx = bsp::hal::uart::Rx<imxrt_iomuxc::consts::U2>;
 
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
@@ -78,7 +78,7 @@ const APP: () = {
         );
         let mut uart = uarts
             .uart2
-            .init(cx.device.pins.p14.alt2(), cx.device.pins.p15.alt2(), BAUD)
+            .init(cx.device.pins.p14, cx.device.pins.p15, BAUD)
             .unwrap();
         uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
         uart.set_rx_fifo(true);
@@ -93,7 +93,7 @@ const APP: () = {
         let (q_tx, q_rx) = unsafe { Q.split() };
 
         // LED setup.
-        let mut led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        let mut led = bsp::configure_led(cx.device.pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.
@@ -132,7 +132,7 @@ const APP: () = {
         }
 
         // Toggle the LED.
-        cx.resources.led.toggle().unwrap();
+        cx.resources.led.toggle();
 
         // Schedule the following blink.
         cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();

--- a/examples/rtic_led.rs
+++ b/examples/rtic_led.rs
@@ -24,9 +24,9 @@ const APP: () = {
         let _core: cortex_m::Peripherals = cx.core;
 
         // Device-specific peripherals
-        let mut device: bsp::Peripherals = cx.device;
+        let device: bsp::Peripherals = cx.device;
 
-        let mut led = bsp::configure_led(&mut device.gpr, device.pins.p13);
+        let mut led = bsp::configure_led(device.pins.p13);
         led.set_high().unwrap();
     }
     #[idle]

--- a/examples/rtic_led.rs
+++ b/examples/rtic_led.rs
@@ -25,8 +25,8 @@ const APP: () = {
 
         // Device-specific peripherals
         let device: bsp::Peripherals = cx.device;
-
-        let mut led = bsp::configure_led(device.pins.p13);
+        let pins = bsp::t40::pins(device.iomuxc);
+        let mut led = bsp::configure_led(pins.p13);
         led.set_high().unwrap();
     }
     #[idle]

--- a/examples/rtic_uart_log.rs
+++ b/examples/rtic_uart_log.rs
@@ -16,7 +16,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::serial::Read;
 use heapless::consts::U256;
 use panic_halt as _;
@@ -35,7 +35,7 @@ type Producer = heapless::spsc::Producer<'static, Ty, Cap>;
 type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 
 // The UART receiver.
-type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::uart::module::_2>;
+type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
@@ -67,7 +67,7 @@ const APP: () = {
         );
         let mut uart = uarts
             .uart2
-            .init(cx.device.pins.p14.alt2(), cx.device.pins.p15.alt2(), BAUD)
+            .init(cx.device.pins.p14, cx.device.pins.p15, BAUD)
             .unwrap();
         uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
         uart.set_rx_fifo(true);
@@ -80,7 +80,7 @@ const APP: () = {
         let (q_tx, q_rx) = unsafe { Q.split() };
 
         // LED setup.
-        let mut led = bsp::configure_led(&mut cx.device.gpr, cx.device.pins.p13);
+        let mut led = bsp::configure_led(cx.device.pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.
@@ -119,7 +119,7 @@ const APP: () = {
         }
 
         // Toggle the LED.
-        cx.resources.led.toggle().unwrap();
+        cx.resources.led.toggle();
 
         // Schedule the following blink.
         cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();

--- a/examples/rtic_uart_log.rs
+++ b/examples/rtic_uart_log.rs
@@ -59,16 +59,15 @@ const APP: () = {
             &mut cx.device.dcdc,
         );
 
+        let pins = bsp::t40::pins(cx.device.iomuxc);
+
         // UART setup.
         let uarts = cx.device.uart.clock(
             &mut cx.device.ccm.handle,
             bsp::hal::ccm::uart::ClockSelect::OSC,
             bsp::hal::ccm::uart::PrescalarSelect::DIVIDE_1,
         );
-        let mut uart = uarts
-            .uart2
-            .init(cx.device.pins.p14, cx.device.pins.p15, BAUD)
-            .unwrap();
+        let mut uart = uarts.uart2.init(pins.p14, pins.p15, BAUD).unwrap();
         uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
         uart.set_rx_fifo(true);
         uart.set_receiver_interrupt(Some(0));
@@ -80,7 +79,7 @@ const APP: () = {
         let (q_tx, q_rx) = unsafe { Q.split() };
 
         // LED setup.
-        let mut led = bsp::configure_led(cx.device.pins.p13);
+        let mut led = bsp::configure_led(pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -33,7 +33,9 @@ const SPI_BAUD_RATE_HZ: u32 = 1_000_000;
 #[entry]
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
-    peripherals.usb.init(Default::default());
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    bsp::usb_init(&systick, Default::default()).unwrap();
+    let pins = bsp::t40::pins(peripherals.iomuxc);
 
     peripherals.ccm.pll1.set_arm_clock(
         bsp::hal::ccm::PLL1::ARM_HZ,
@@ -41,7 +43,7 @@ fn main() -> ! {
         &mut peripherals.dcdc,
     );
 
-    peripherals.systick.delay(5000);
+    systick.delay(5000);
     log::info!("Initializing SPI4 clocks...");
 
     let (_, _, _, spi4_builder) = peripherals.spi.clock(
@@ -51,11 +53,7 @@ fn main() -> ! {
     );
 
     log::info!("Constructing SPI4 peripheral...");
-    let mut spi4 = spi4_builder.build(
-        peripherals.pins.p11,
-        peripherals.pins.p12,
-        peripherals.pins.p13,
-    );
+    let mut spi4 = spi4_builder.build(pins.p11, pins.p12, pins.p13);
 
     match spi4.set_clock_speed(bsp::hal::spi::ClockSpeed(SPI_BAUD_RATE_HZ)) {
         Ok(()) => {
@@ -76,7 +74,7 @@ fn main() -> ! {
     // We're using the SPI's default chip select pin. This uses a
     // dummy `OutputPin` that does nothing! If you'd rather use any
     // GPIO, replace this line to construct a GPIO from another pin.
-    spi4.enable_chip_select_0(peripherals.pins.p10);
+    spi4.enable_chip_select_0(pins.p10);
     struct DummyCS;
     impl embedded_hal::digital::v2::OutputPin for DummyCS {
         type Error = core::convert::Infallible;
@@ -89,9 +87,9 @@ fn main() -> ! {
     }
     let mut cs4 = DummyCS;
     log::info!("Waiting 5 seconds before querying MPU9250...");
-    peripherals.systick.delay(4000);
+    systick.delay(4000);
 
-    match ak8963_init(&mut peripherals.systick, &mut spi4, &mut cs4) {
+    match ak8963_init(&mut systick, &mut spi4, &mut cs4) {
         Ok(()) => (),
         Err(err) => {
             log::warn!("Unable to initialize AK8963: {:?}", err);
@@ -101,7 +99,7 @@ fn main() -> ! {
         }
     };
     loop {
-        peripherals.systick.delay(1000);
+        systick.delay(1000);
         match who_am_i(&mut spi4, &mut cs4) {
             Ok(who) => log::info!("Received {:#X} for WHO_AM_I", who),
             Err(err) => log::warn!("Error when querying WHO_AM_I: {:?}", err),

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -34,7 +34,7 @@ const SPI_BAUD_RATE_HZ: u32 = 1_000_000;
 fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     let pins = bsp::t40::pins(peripherals.iomuxc);
 
     peripherals.ccm.pll1.set_arm_clock(

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -52,9 +52,9 @@ fn main() -> ! {
 
     log::info!("Constructing SPI4 peripheral...");
     let mut spi4 = spi4_builder.build(
-        peripherals.pins.p11.alt3(),
-        peripherals.pins.p12.alt3(),
-        peripherals.pins.p13.alt3(),
+        peripherals.pins.p11,
+        peripherals.pins.p12,
+        peripherals.pins.p13,
     );
 
     match spi4.set_clock_speed(bsp::hal::spi::ClockSpeed(SPI_BAUD_RATE_HZ)) {
@@ -76,7 +76,7 @@ fn main() -> ! {
     // We're using the SPI's default chip select pin. This uses a
     // dummy `OutputPin` that does nothing! If you'd rather use any
     // GPIO, replace this line to construct a GPIO from another pin.
-    spi4.enable_chip_select_0(peripherals.pins.p10.alt3());
+    spi4.enable_chip_select_0(peripherals.pins.p10);
     struct DummyCS;
     impl embedded_hal::digital::v2::OutputPin for DummyCS {
         type Error = core::convert::Infallible;

--- a/examples/systick.rs
+++ b/examples/systick.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 #![no_main]
+
 extern crate panic_halt;
 
 use bsp::rt;
@@ -15,11 +16,13 @@ const LED_PERIOD_MS: u32 = 1_000;
 
 #[rt::entry]
 fn main() -> ! {
-    let mut p = bsp::Peripherals::take().unwrap();
-    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
+    let p = bsp::Peripherals::take().unwrap();
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    let pins = bsp::t40::pins(p.iomuxc);
+    let mut led: bsp::LED = bsp::configure_led(pins.p13);
 
     loop {
-        p.systick.delay(LED_PERIOD_MS);
+        systick.delay(LED_PERIOD_MS);
         led.toggle();
     }
 }

--- a/examples/systick.rs
+++ b/examples/systick.rs
@@ -9,7 +9,6 @@
 extern crate panic_halt;
 
 use bsp::rt;
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use teensy4_bsp as bsp;
 
 const LED_PERIOD_MS: u32 = 1_000;
@@ -17,10 +16,10 @@ const LED_PERIOD_MS: u32 = 1_000;
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
-    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
 
     loop {
         p.systick.delay(LED_PERIOD_MS);
-        led.toggle().unwrap();
+        led.toggle();
     }
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
 
     let (timer0, timer1, _, mut timer3) = periphs.pit.clock(&mut cfg);
     let mut timer = pit::chain(timer0, timer1);
-    let mut led: bsp::LED = bsp::configure_led(&mut periphs.gpr, periphs.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(periphs.pins.p13);
     let mut systick = periphs.systick;
     loop {
         let (_, period) = timer.time(|| {

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     let mut periphs = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     let pins = bsp::t40::pins(periphs.iomuxc);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
 
     let (_, ipg_hz) = periphs.ccm.pll1.set_arm_clock(
         bsp::hal::ccm::PLL1::ARM_HZ,

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -81,7 +81,7 @@ fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     let pins = bsp::t40::pins(peripherals.iomuxc);
-    bsp::usb_init(&systick, Default::default()).unwrap();
+    bsp::usb::init(&systick, Default::default()).unwrap();
     systick.delay(5_000);
     let uarts = peripherals.uart.clock(
         &mut peripherals.ccm.handle,

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -23,7 +23,6 @@ extern crate panic_halt;
 use bsp::rt::entry;
 use teensy4_bsp as bsp;
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use embedded_hal::serial::{Read, Write};
 
 const BAUD: u32 = 115_200;
@@ -89,11 +88,7 @@ fn main() -> ! {
     );
     let mut uart = uarts
         .uart2
-        .init(
-            peripherals.pins.p14.alt2(),
-            peripherals.pins.p15.alt2(),
-            BAUD,
-        )
+        .init(peripherals.pins.p14, peripherals.pins.p15, BAUD)
         .unwrap();
     let fifo_size = uart.set_tx_fifo(core::num::NonZeroU8::new(TX_FIFO_SIZE));
     log::info!("Setting TX FIFO to {}", fifo_size);
@@ -102,11 +97,11 @@ fn main() -> ! {
     uart.set_parity(PARITY);
     uart.set_rx_inversion(INVERTED);
     uart.set_tx_inversion(INVERTED);
-    let mut led = bsp::configure_led(&mut peripherals.gpr, peripherals.pins.p13);
+    let mut led = bsp::configure_led(peripherals.pins.p13);
     let (mut tx, mut rx) = uart.split();
     loop {
         peripherals.systick.delay(1_000);
-        led.toggle().unwrap();
+        led.toggle();
         let mut buffer = DATA;
         write(&mut tx, &buffer).unwrap();
         peripherals.systick.delay(1);

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -13,8 +13,6 @@ extern crate panic_halt;
 use bsp::rt;
 use teensy4_bsp as bsp;
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
-
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
@@ -27,7 +25,7 @@ fn main() -> ! {
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
     let mut buffer = [0; 256];
     loop {
         let bytes_read = usb_reader.read(&mut buffer);
@@ -49,7 +47,7 @@ fn main() -> ! {
         log::info!("It's 31'C outside");
         log::debug!("Sleeping for 1 second...");
         log::trace!("{} + {} = {}", 3, 2, 3 + 2);
-        led.toggle().unwrap();
+        led.toggle();
         p.systick.delay(5000);
     }
 }

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
     let pins = bsp::t40::pins(p.iomuxc);
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     // Initialize the USB stack with the default logging settings
-    let mut usb_reader = bsp::usb_init(
+    let mut usb_reader = bsp::usb::init(
         &systick,
         bsp::usb::LoggingConfig {
             filters: &[("usb", None)],

--- a/examples/usb_writer.rs
+++ b/examples/usb_writer.rs
@@ -10,8 +10,6 @@ use bsp::rt;
 use core::fmt::Write;
 use teensy4_bsp as bsp;
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
-
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
@@ -21,7 +19,7 @@ fn main() -> ! {
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(&mut p.gpr, p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
     let mut buffer = [0; 256];
     loop {
         let bytes_read = reader.read(&mut buffer);
@@ -39,7 +37,7 @@ fn main() -> ! {
         }
 
         writeln!(writer, "Hello world! 3 + 2 = {}", 3 + 2).unwrap();
-        led.toggle().unwrap();
+        led.toggle();
         p.systick.delay(5000);
     }
 }

--- a/examples/usb_writer.rs
+++ b/examples/usb_writer.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
     let pins = bsp::t40::pins(p.iomuxc);
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     // Split the USB stack into read / write halves
-    let (mut reader, mut writer) = bsp::usb::split().unwrap();
+    let (mut reader, mut writer) = bsp::usb::split(&systick).unwrap();
     systick.delay(2000);
     p.ccm
         .pll1

--- a/examples/usb_writer.rs
+++ b/examples/usb_writer.rs
@@ -13,13 +13,15 @@ use teensy4_bsp as bsp;
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
+    let pins = bsp::t40::pins(p.iomuxc);
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     // Split the USB stack into read / write halves
-    let (mut reader, mut writer) = p.usb.split();
-    p.systick.delay(2000);
+    let (mut reader, mut writer) = bsp::usb::split().unwrap();
+    systick.delay(2000);
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(p.pins.p13);
+    let mut led: bsp::LED = bsp::configure_led(pins.p13);
     let mut buffer = [0; 256];
     loop {
         let bytes_read = reader.read(&mut buffer);
@@ -38,6 +40,6 @@ fn main() -> ! {
 
         writeln!(writer, "Hello world! 3 + 2 = {}", 3 + 2).unwrap();
         led.toggle();
-        p.systick.delay(5000);
+        systick.delay(5000);
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,133 @@
+//! Common APIs across both the Teensy 4.0 and 4.1 boards
+//!
+//! # Common Pinout
+//!
+//! The Teensy 4.0 and 4.1 have many similar pad to pin mappings. This table documents
+//! the pins that are common across both boards. For pins that are unique to
+//! each board, and to acquire all of a board's pins, see the [`t40`](../t40/index.html)
+//! and [`t41`](../t41/index.html) modules.
+//!
+//! ## This table is incomplete
+//!
+//! We believe this table's contents are accurate. But, there may be alternate functions that are not
+//! documented, and we're maintaining this table on a best-effort basis. Besides this table,
+//! there are two other ways to identify which pads support which peripheral:
+//!
+//! - study the i.MX RT 1060 Reference Manual. This is the authority on pad configuration.
+//! - study the trait implementations for the pad. Select a pin type alias, like [`P0`](type.P0.html),
+//!   and click-through to its pad documentation (`AD_B0_03`). Notice the listing of `imxrt-iomuxc`
+//!   trait implementations. This describes what kinds of functions the pin supports. The constraints
+//!   may be enforced by the HAL's APIs.
+//!
+//! We welcome documentation contributions!
+//!
+//! | Pin  | Pad ID   |  Alt0    |  Alt1        |  Alt2        |  Alt3     |  Alt4        |  Alt5            |  Alt6        |  Alt7   |  Alt8   |  Alt9   |
+//! | ---- | -------- | -------- | ------------ | ------------ | --------- | ------------ | ---------------- | ------------ | ------- | ------- | ------- |
+//! |  0   |`AD_B0_03`|          |              |  `UART6_RX`  |           |`FlexPWM1_1_X`|                  |              |         |         |         |
+//! |  1   |`AD_B0_02`|          |              |  `UART6_TX`  |           |`FlexPWM1_0_X`|                  |              |         |         |         |
+//! |  2   |`EMC_04`  |          |`FlexPWM4_2_A`|              |           |              |                  |              |         |         |         |
+//! |  3   |`EMC_05`  |          |`FlexPWM4_2_B`|              |           |              |                  |              |         |         |         |
+//! |  4   |`EMC_06`  |          |`FlexPWM2_0_A`|              |           |              |                  |              |         |         |         |
+//! |  5   |`EMC_08`  |          |`FlexPWM2_1_A`|              |           |              |                  |              |         |         |         |
+//! |  6   |`B0_10`   |          |              |`FlexPWM2_2_A`|           |              |                  |              |         |         |         |
+//! |  7   |`B1_01`   |          |              |  `UART4_RX`  |           |              |                  |`FlexPWM1_3_B`|         |         |         |
+//! |  8   |`B1_00`   |          |              |  `UART4_TX`  |           |              |                  |`FlexPWM1_3_A`|         |         |         |
+//! |  9   |`B0_11`   |          |              |`FlexPWM2_2_B`|           |              |                  |              |         |         |         |
+//! |  10  |`B0_00`   |          |              |              |`SPI4_PCS0`|              |                  |              |         |         |         |
+//! |  11  |`B0_02`   |          |              |              |`SPI4_SDO` |              |                  |              |         |         |         |
+//! |  12  |`B0_01`   |          |              |              |`SPI4_SDI` |              |                  |              |         |         |         |
+//! |  13  |`B0_03`   |          |              |              |`SPI4_SCK` |              |`GPIO2_3` (`LED`) |              |         |         |         |
+//! |  14  |`AD_B1_02`|          |              |  `UART2_TX`  |           |              |                  |              |         |         |         |
+//! |  15  |`AD_B1_03`|          |              |  `UART2_RX`  |           |              |                  |              |         |         |         |
+//! |  16  |`AD_B1_07`|          |`I2C3_SCL`    |  `UART3_RX`  |           |              |                  |              |         |         |         |
+//! |  17  |`AD_B1_06`|          |`I2C3_SDA`    |  `UART3_TX`  |           |              |                  |              |         |         |         |
+//! |  18  |`AD_B1_01`|          |              |              |`I2C1_SDA` |              |                  |              |         |         |         |
+//! |  19  |`AD_B1_00`|          |              |  `UART2_CTS` |`I2C1_SCL` |              |                  |              |         |         |         |
+//! |  20  |`AD_B1_10`|          |              |  `UART8_TX`  |           |              |                  |              |         |         |         |
+//! |  21  |`AD_B1_11`|          |              |  `UART8_RX`  |           |              |                  |              |         |         |         |
+//! |  22  |`AD_B1_08`|          |`FlexPWM4_0_A`|              |           |              |                  |              |         |         |         |
+//! |  23  |`AD_B1_09`|          |`FlexPWM4_1_A`|              |           |              |                  |              |         |         |         |
+//! |  24  |`AD_B0_12`|`I2C4_SCL`|              |  `UART1_TX`  |           |`FlexPWM1_2_X`|                  |              |         |         |         |
+//! |  25  |`AD_B0_13`|`I2C4_SDA`|              |  `UART1_RX`  |           |`FlexPWM1_3_X`|                  |              |         |         |         |
+//! |  26  |`AD_B1_14`|          |              |              |           |              |                  |              |         |         |         |
+//! |  27  |`AD_B1_15`|          |              |              |           |              |                  |              |         |         |         |
+//! |  28  |`EMC_32`  |          |`FlexPWM3_1_B`|  `UART7_RX`  |           |              |                  |              |         |         |         |
+//! |  29  |`EMC_31`  |          |`FlexPWM3_1_A`|  `UART7_TX`  |`SPI1_PCS1`|              |                  |              |         |         |         |
+//! |  30  |`EMC_37`  |          |              |              |           |              |                  |              |         |         |         |
+//! |  31  |`EMC_36`  |          |              |              |           |              |                  |              |         |         |         |
+//! |  32  |`B0_12`   |          |              |              |           |              |                  |              |         |         |         |
+//! |  33  |`EMC_07`  |          |`FlexPWM2_0_B`|              |           |              |                  |              |         |         |         |
+//!
+//! References:
+//! - [Teensy Schematics](https://www.pjrc.com/teensy/schematic.html)
+
+use crate::hal::iomuxc::{ad_b0::*, ad_b1::*, b0::*, b1::*, emc::*};
+
+/// Pin 0 (common)
+pub type P0 = AD_B0_03;
+/// Pin 1 (common)
+pub type P1 = AD_B0_02;
+/// Pin 2 (common)
+pub type P2 = EMC_04;
+/// Pin 3 (common)
+pub type P3 = EMC_05;
+/// Pin 4 (common)
+pub type P4 = EMC_06;
+/// Pin 5 (common)
+pub type P5 = EMC_08;
+/// Pin 6 (common)
+pub type P6 = B0_10;
+/// Pin 7 (common)
+pub type P7 = B1_01;
+/// Pin 8 (common)
+pub type P8 = B1_00;
+/// Pin 9 (common)
+pub type P9 = B0_11;
+/// Pin 10 (common)
+pub type P10 = B0_00;
+/// Pin 11 (common)
+pub type P11 = B0_02;
+/// Pin 12 (common)
+pub type P12 = B0_01;
+/// Pin 13 (common)
+pub type P13 = B0_03;
+/// Pin 14 (common)
+pub type P14 = AD_B1_02;
+/// Pin 15 (common)
+pub type P15 = AD_B1_03;
+/// Pin 16 (common)
+pub type P16 = AD_B1_07;
+/// Pin 17 (common)
+pub type P17 = AD_B1_06;
+/// Pin 18 (common)
+pub type P18 = AD_B1_01;
+/// Pin 19 (common)
+pub type P19 = AD_B1_00;
+/// Pin 20 (common)
+pub type P20 = AD_B1_10;
+/// Pin 21 (common)
+pub type P21 = AD_B1_11;
+/// Pin 22 (common)
+pub type P22 = AD_B1_08;
+/// Pin 23 (common)
+pub type P23 = AD_B1_09;
+/// Pin 24 (common)
+pub type P24 = AD_B0_12;
+/// Pin 25 (common)
+pub type P25 = AD_B0_13;
+/// Pin 26 (common)
+pub type P26 = AD_B1_14;
+/// Pin 27 (common)
+pub type P27 = AD_B1_15;
+/// Pin 28 (common)
+pub type P28 = EMC_32;
+/// Pin 29 (common)
+pub type P29 = EMC_31;
+/// Pin 30 (common)
+pub type P30 = EMC_37;
+/// Pin 31 (common)
+pub type P31 = EMC_36;
+/// Pin 32 (common)
+pub type P32 = B0_12;
+/// Pin 33 (common)
+pub type P33 = EMC_07;

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,6 +14,7 @@
 //! pins API. The second uses the processor pad that drivers the LED.
 //!
 //! ```no_run
+//! // Using the BSP's pin API
 //! use teensy4_bsp as bsp;
 //! let peripherals = bsp::Peripherals::take().unwrap();
 //! let pins = bsp::t40::pins(peripherals.iomuxc);
@@ -21,6 +22,7 @@
 //! ```
 //!
 //! ```no_run
+//! // Using i.MX RT pads instead of Teensy pins
 //! use teensy4_bsp as bsp;
 //! let peripherals = bsp::Peripherals::take().unwrap();
 //! let led = bsp::configure_led(peripherals.iomuxc.b0.p03);

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,14 +2,35 @@
 //!
 //! # Common Pinout
 //!
-//! The Teensy 4.0 and 4.1 have many similar pad to pin mappings. This module provides
+//! The Teensy 4.0 and 4.1 share many pins. This module provides
 //! the pins that are common across both boards. For pins that are unique to
 //! each board, and to acquire all of a board's pins, see the [`t40`](../t40/index.html)
 //! and [`t41`](../t41/index.html) modules.
 //!
-//! ## This table is incomplete
+//! Note that this pin API is optional, provided only for convenience. You are free to
+//! configure the pins using the pad identifiers, instead of the physical pin identifiers.
 //!
-//! We believe this table's contents are accurate. But, there may be alternate functions that are not
+//! The following examples are equivalent ways to configure the LED. The first uses the
+//! pins API. The second uses the processor pad that drivers the LED.
+//!
+//! ```no_run
+//! use teensy4_bsp as bsp;
+//! let peripherals = bsp::Peripherals::take().unwrap();
+//! let pins = bsp::t40::pins(peripherals.iomuxc);
+//! let led = bsp::configure_led(pins.p13);
+//! ```
+//!
+//! ```no_run
+//! use teensy4_bsp as bsp;
+//! let peripherals = bsp::Peripherals::take().unwrap();
+//! let led = bsp::configure_led(peripherals.iomuxc.b0.p03);
+//! ```
+//!
+//! ## Common pin table
+//!
+//! **This table is incomplete**
+//!
+//! We believe this table is accurate. But, there may be alternate functions that are not
 //! documented, and we're maintaining this table on a best-effort basis. Besides this table,
 //! there are two other ways to identify which pads support which peripheral:
 //!

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@
 //!
 //! # Common Pinout
 //!
-//! The Teensy 4.0 and 4.1 have many similar pad to pin mappings. This table documents
+//! The Teensy 4.0 and 4.1 have many similar pad to pin mappings. This module provides
 //! the pins that are common across both boards. For pins that are unique to
 //! each board, and to acquire all of a board's pins, see the [`t40`](../t40/index.html)
 //! and [`t41`](../t41/index.html) modules.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,9 @@ pub use hal::ral::interrupt;
 pub use hal::ral::{interrupt as Interrupt, NVIC_PRIO_BITS};
 
 pub use cortex_m_rt as rt;
-pub use imxrt_hal as hal;
-
 use hal::iomuxc;
+pub use hal::Peripherals;
+pub use imxrt_hal as hal;
 
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,74 +127,77 @@ pub use cortex_m_rt as rt;
 pub use imxrt_hal as hal;
 
 /// The LED in its final configuration
-pub type LED = hal::gpio::GPIO2IO03<hal::gpio::GPIO7, hal::gpio::Output>;
+pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
+
+use imxrt106x_iomuxc as iomuxc;
+use imxrt_iomuxc::consts::{U1, U2, U3, U4};
 
 /// Teensy pins that do not yet have a function
 ///
 /// Pin 13 can be used for several things; one common usage is for the on-board LED.
 pub struct Pins {
     /// Pin 0
-    pub p0: hal::iomuxc::gpio::GPIO_AD_B0_03<hal::iomuxc::Alt5>,
+    pub p0: iomuxc::ad_b0::AD_B0_03,
     /// Pin 1
-    pub p1: hal::iomuxc::gpio::GPIO_AD_B0_02<hal::iomuxc::Alt5>,
+    pub p1: iomuxc::ad_b0::AD_B0_02,
     /// Pin 2
-    pub p2: hal::iomuxc::gpio::GPIO_EMC_04<hal::iomuxc::Alt5>,
+    pub p2: iomuxc::emc::EMC_04,
     /// Pin 3
-    pub p3: hal::iomuxc::gpio::GPIO_EMC_05<hal::iomuxc::Alt5>,
+    pub p3: iomuxc::emc::EMC_05,
     /// Pin 4
-    pub p4: hal::iomuxc::gpio::GPIO_EMC_06<hal::iomuxc::Alt5>,
+    pub p4: iomuxc::emc::EMC_06,
     /// Pin 5
-    pub p5: hal::iomuxc::gpio::GPIO_EMC_08<hal::iomuxc::Alt5>,
+    pub p5: iomuxc::emc::EMC_08,
     /// Pin 6
-    pub p6: hal::iomuxc::gpio::GPIO_B0_10<hal::iomuxc::Alt5>,
+    pub p6: iomuxc::b0::B0_10,
     /// Pin 7
-    pub p7: hal::iomuxc::gpio::GPIO_B1_01<hal::iomuxc::Alt5>,
+    pub p7: iomuxc::b1::B1_01,
     /// Pin 8
-    pub p8: hal::iomuxc::gpio::GPIO_B1_00<hal::iomuxc::Alt5>,
+    pub p8: iomuxc::b1::B1_00,
     /// Pin 9
-    pub p9: hal::iomuxc::gpio::GPIO_B0_11<hal::iomuxc::Alt5>,
+    pub p9: iomuxc::b0::B0_11,
     /// Pin 10
-    pub p10: hal::iomuxc::gpio::GPIO_B0_00<hal::iomuxc::Alt5>,
+    pub p10: iomuxc::b0::B0_00,
     /// Pin 11
-    pub p11: hal::iomuxc::gpio::GPIO_B0_02<hal::iomuxc::Alt5>,
+    pub p11: iomuxc::b0::B0_02,
     /// Pin 12
-    pub p12: hal::iomuxc::gpio::GPIO_B0_01<hal::iomuxc::Alt5>,
+    pub p12: iomuxc::b0::B0_01,
     /// Pin 13
-    pub p13: hal::iomuxc::gpio::GPIO_B0_03<hal::iomuxc::Alt5>,
+    pub p13: iomuxc::b0::B0_03,
     /// Pin 14
-    pub p14: hal::iomuxc::gpio::GPIO_AD_B1_02<hal::iomuxc::Alt5>,
+    pub p14: iomuxc::ad_b1::AD_B1_02,
     /// Pin 15
-    pub p15: hal::iomuxc::gpio::GPIO_AD_B1_03<hal::iomuxc::Alt5>,
+    pub p15: iomuxc::ad_b1::AD_B1_03,
     /// Pin 16
-    pub p16: hal::iomuxc::gpio::GPIO_AD_B1_07<hal::iomuxc::Alt5>,
+    pub p16: iomuxc::ad_b1::AD_B1_07,
     /// Pin 17
-    pub p17: hal::iomuxc::gpio::GPIO_AD_B1_06<hal::iomuxc::Alt5>,
+    pub p17: iomuxc::ad_b1::AD_B1_06,
     /// Pin 18
-    pub p18: hal::iomuxc::gpio::GPIO_AD_B1_01<hal::iomuxc::Alt5>,
+    pub p18: iomuxc::ad_b1::AD_B1_01,
     /// Pin 19
-    pub p19: hal::iomuxc::gpio::GPIO_AD_B1_00<hal::iomuxc::Alt5>,
+    pub p19: iomuxc::ad_b1::AD_B1_00,
     /// Pin 20
-    pub p20: hal::iomuxc::gpio::GPIO_AD_B1_10<hal::iomuxc::Alt5>,
+    pub p20: iomuxc::ad_b1::AD_B1_10,
     /// Pin 21
-    pub p21: hal::iomuxc::gpio::GPIO_AD_B1_11<hal::iomuxc::Alt5>,
+    pub p21: iomuxc::ad_b1::AD_B1_11,
     /// Pin 22
-    pub p22: hal::iomuxc::gpio::GPIO_AD_B1_08<hal::iomuxc::Alt5>,
+    pub p22: iomuxc::ad_b1::AD_B1_08,
     /// Pin 23
-    pub p23: hal::iomuxc::gpio::GPIO_AD_B1_09<hal::iomuxc::Alt5>,
+    pub p23: iomuxc::ad_b1::AD_B1_09,
     /// Pin 24
-    pub p24: hal::iomuxc::gpio::GPIO_AD_B0_12<hal::iomuxc::Alt5>,
+    pub p24: iomuxc::ad_b0::AD_B0_12,
     /// Pin 25
-    pub p25: hal::iomuxc::gpio::GPIO_AD_B0_13<hal::iomuxc::Alt5>,
+    pub p25: iomuxc::ad_b0::AD_B0_13,
     /// Pin 28
-    pub p28: hal::iomuxc::gpio::GPIO_EMC_32<hal::iomuxc::Alt5>,
+    pub p28: iomuxc::emc::EMC_32,
     /// Pin 29
-    pub p29: hal::iomuxc::gpio::GPIO_EMC_31<hal::iomuxc::Alt5>,
+    pub p29: iomuxc::emc::EMC_31,
     /// Pin 33
-    pub p33: hal::iomuxc::gpio::GPIO_EMC_07<hal::iomuxc::Alt5>,
+    pub p33: iomuxc::emc::EMC_07,
     /// Pin 36
-    pub p36: hal::iomuxc::gpio::GPIO_SD_B0_01<hal::iomuxc::Alt5>,
+    pub p36: iomuxc::sd_b0::SD_B0_01,
     /// Pin 37
-    pub p37: hal::iomuxc::gpio::GPIO_SD_B0_00<hal::iomuxc::Alt5>,
+    pub p37: iomuxc::sd_b0::SD_B0_00,
 }
 
 /// All peripherals available on the Teensy4
@@ -217,13 +220,13 @@ pub struct Peripherals {
     /// DCDC converters
     pub dcdc: hal::dcdc::DCDC,
     /// PWM1 controller
-    pub pwm1: hal::pwm::Unclocked<hal::pwm::module::_1>,
+    pub pwm1: hal::pwm::Unclocked<U1>,
     /// PWM2 controller
-    pub pwm2: hal::pwm::Unclocked<hal::pwm::module::_2>,
+    pub pwm2: hal::pwm::Unclocked<U2>,
     /// PWM3 controller
-    pub pwm3: hal::pwm::Unclocked<hal::pwm::module::_3>,
+    pub pwm3: hal::pwm::Unclocked<U3>,
     /// PWM4 controller
-    pub pwm4: hal::pwm::Unclocked<hal::pwm::module::_4>,
+    pub pwm4: hal::pwm::Unclocked<U4>,
     /// Teensy pins
     pub pins: Pins,
     /// Unclocked I2C peripherals
@@ -232,8 +235,6 @@ pub struct Peripherals {
     pub spi: hal::spi::Unclocked,
     /// Unclocked UART peripherals
     pub uart: hal::uart::Unclocked,
-    /// General purpose registers, used when configuring GPIO pins.
-    pub gpr: hal::iomuxc::GPR,
     /// General purpose timer 1
     pub gpt1: hal::gpt::Unclocked,
     /// General purpose timer 2
@@ -294,42 +295,41 @@ impl Peripherals {
             pwm3: p.pwm3,
             pwm4: p.pwm4,
             pins: Pins {
-                p0: p.iomuxc.gpio_ad_b0_03,
-                p1: p.iomuxc.gpio_ad_b0_02,
-                p2: p.iomuxc.gpio_emc_04,
-                p3: p.iomuxc.gpio_emc_05,
-                p4: p.iomuxc.gpio_emc_06,
-                p5: p.iomuxc.gpio_emc_08,
-                p6: p.iomuxc.gpio_b0_10,
-                p7: p.iomuxc.gpio_b1_01,
-                p8: p.iomuxc.gpio_b1_00,
-                p9: p.iomuxc.gpio_b0_11,
-                p10: p.iomuxc.gpio_b0_00,
-                p11: p.iomuxc.gpio_b0_02,
-                p12: p.iomuxc.gpio_b0_01,
-                p13: p.iomuxc.gpio_b0_03,
-                p14: p.iomuxc.gpio_ad_b1_02,
-                p15: p.iomuxc.gpio_ad_b1_03,
-                p16: p.iomuxc.gpio_ad_b1_07,
-                p17: p.iomuxc.gpio_ad_b1_06,
-                p18: p.iomuxc.gpio_ad_b1_01,
-                p19: p.iomuxc.gpio_ad_b1_00,
-                p20: p.iomuxc.gpio_ad_b1_10,
-                p21: p.iomuxc.gpio_ad_b1_11,
-                p22: p.iomuxc.gpio_ad_b1_08,
-                p23: p.iomuxc.gpio_ad_b1_09,
-                p24: p.iomuxc.gpio_ad_b0_12,
-                p25: p.iomuxc.gpio_ad_b0_13,
-                p28: p.iomuxc.gpio_emc_32,
-                p29: p.iomuxc.gpio_emc_31,
-                p33: p.iomuxc.gpio_emc_07,
-                p36: p.iomuxc.gpio_sd_b0_01,
-                p37: p.iomuxc.gpio_sd_b0_00,
+                p0: p.iomuxc.ad_b0.p03,
+                p1: p.iomuxc.ad_b0.p02,
+                p2: p.iomuxc.emc.p04,
+                p3: p.iomuxc.emc.p05,
+                p4: p.iomuxc.emc.p06,
+                p5: p.iomuxc.emc.p08,
+                p6: p.iomuxc.b0.p10,
+                p7: p.iomuxc.b1.p01,
+                p8: p.iomuxc.b1.p00,
+                p9: p.iomuxc.b0.p11,
+                p10: p.iomuxc.b0.p00,
+                p11: p.iomuxc.b0.p02,
+                p12: p.iomuxc.b0.p01,
+                p13: p.iomuxc.b0.p03,
+                p14: p.iomuxc.ad_b1.p02,
+                p15: p.iomuxc.ad_b1.p03,
+                p16: p.iomuxc.ad_b1.p07,
+                p17: p.iomuxc.ad_b1.p06,
+                p18: p.iomuxc.ad_b1.p01,
+                p19: p.iomuxc.ad_b1.p00,
+                p20: p.iomuxc.ad_b1.p10,
+                p21: p.iomuxc.ad_b1.p11,
+                p22: p.iomuxc.ad_b1.p08,
+                p23: p.iomuxc.ad_b1.p09,
+                p24: p.iomuxc.ad_b0.p12,
+                p25: p.iomuxc.ad_b0.p13,
+                p28: p.iomuxc.emc.p32,
+                p29: p.iomuxc.emc.p31,
+                p33: p.iomuxc.emc.p07,
+                p36: p.iomuxc.sd_b0.p01,
+                p37: p.iomuxc.sd_b0.p00,
             },
             i2c: p.i2c,
             spi: p.spi,
             uart: p.uart,
-            gpr: p.iomuxc.gpr,
             gpt1: p.gpt1,
             gpt2: p.gpt2,
             dma: p.dma,
@@ -343,9 +343,10 @@ impl Peripherals {
 ///
 /// Returns a GPIO that's physically tied to the LED. Use the returned handle
 /// to drive the LED.
-pub fn configure_led<A>(gpr: &mut hal::iomuxc::GPR, pad: hal::iomuxc::gpio::GPIO_B0_03<A>) -> LED {
-    use hal::gpio::IntoGpio;
-    pad.alt5().into_gpio().fast(gpr).output()
+pub fn configure_led(pad: iomuxc::b0::B0_03) -> LED {
+    let mut led = hal::gpio::GPIO::new(pad);
+    led.set_fast(true);
+    led.output()
 }
 
 /// TODO(mciantyre) define a better yield

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,6 @@ pub mod usb;
 
 #[cfg(feature = "systick")]
 pub use systick::SysTick;
-#[cfg(feature = "usb-logging")]
-pub use usb::{init as usb_init, LoggingConfig};
 
 pub use hal::ral::interrupt;
 // `rtic` expects these in the root.
@@ -80,7 +78,9 @@ use hal::iomuxc;
 pub use hal::Peripherals;
 pub use imxrt_hal as hal;
 
-/// The LED in its final configuration
+/// The LED
+///
+/// See [`configure_led`](fn.configure_led.html) to prepare the LED.
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
 
 /// Configure the board's LED

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@ pub use imxrt_hal as hal;
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
 
-use imxrt106x_iomuxc as iomuxc;
-use imxrt_iomuxc::consts::{U1, U2, U3, U4};
+use hal::iomuxc as iomuxc;
+use iomuxc::consts::{U1, U2, U3, U4};
 
 /// Teensy pins that do not yet have a function
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //!   continuous days, or risk a millisecond counter wrap-around.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Need to reference this so that it doesn't get stripped out
 extern crate teensy4_fcb;
@@ -63,6 +64,7 @@ pub mod t40;
 #[cfg(feature = "systick")]
 mod systick;
 #[cfg(feature = "usb-logging")]
+#[cfg_attr(docsrs, doc(cfg(feature = "usb-logging")))]
 pub mod usb;
 
 #[cfg(feature = "systick")]
@@ -70,6 +72,7 @@ pub use systick::SysTick;
 
 pub use hal::ral::interrupt;
 // `rtic` expects these in the root.
+#[doc(hidden)]
 #[cfg(feature = "rtic")]
 pub use hal::ral::{interrupt as Interrupt, NVIC_PRIO_BITS};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub use imxrt_hal as hal;
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
 
-use hal::iomuxc as iomuxc;
+use hal::iomuxc;
 use iomuxc::consts::{U1, U2, U3, U4};
 
 /// Teensy pins that do not yet have a function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@ pub use hal::ral::interrupt;
 pub use hal::ral::{interrupt as Interrupt, NVIC_PRIO_BITS};
 
 pub use cortex_m_rt as rt;
-use hal::iomuxc;
 pub use hal::Peripherals;
 pub use imxrt_hal as hal;
 
@@ -92,7 +91,7 @@ pub type LED = hal::gpio::GPIO<common::P13, hal::gpio::Output>;
 ///
 /// Returns a GPIO that's physically tied to the LED. Use the returned handle
 /// to drive the LED.
-pub fn configure_led(pad: iomuxc::b0::B0_03) -> LED {
+pub fn configure_led(pad: common::P13) -> LED {
     let mut led = hal::gpio::GPIO::new(pad);
     led.set_fast(true);
     led.output()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,17 @@
-//! A Rust board support package (BSP) for the Teensy 4.
+//! A Rust board support package (BSP) for the Teensy 4. Supports the Teensy 4.0 and
+//! 4.1 boards.
 //!
-//! The BSP is mainly a pass-through of the `imxrt-hal` hardware abstraction layer.
+//! Peripherals are re-exported from the [`imxrt-rs`](https://docs.rs/imxrt-hal/latest/imxrt_hal/)
+//! hardware abstraction layer. See the HAL's documentation for more information on creating
+//! and using peripherals.
+//!
 //! The BSP restricts the processor pads that are available, since the physical Teensy
 //! only has a few user-accessible pins. From these pins, you may construct peripherals
-//! and perform I/O.
+//! and perform I/O. The two Teensy 4 boards support many of the same pins; see the
+//! [`common`](common/index.html) module for those similar pins. To construct Teensy 4.0
+//! or 4.1 pins, see the corresponding `pins` function in each of the corresponding modules.
 //!
-//! The BSP also exposes a USB logging interface. See the [`usb`](usb/index.html) module
-//! for more details.
-//!
-//! The BSP does assume some facilities of the processor, both which are required for the
+//! The BSP assumes some facilities of the processor, both which are required for the
 //! USB stack. Each are controllable through feature-flags. Each feature is on by default.
 //!
 //! - it registers the `SysTick` exception handler, and configures
@@ -18,7 +21,6 @@
 //!   peripheral for logging. Enabled with the `"usb-logging"` feature,
 //!   which is on by default. Depends on the `"systick"` feature.
 //!
-//! These peripherals and capabilities are not exported from the BSP.
 //! If a user also registers a `SysTick` or `USB_OTG1` handler, it may
 //! result in a duplicate definition error.
 //!
@@ -74,6 +76,37 @@
 //! See the `teensy4-examples` crate for build-able, run-able
 //! examples. The examples utilize this BSP crate to blink LEDs,
 //! establish timers, and log data over USB.
+//!
+//! # Using RTIC
+//!
+//! To develop Teensy 4 applications with the RTIC framework,
+//!
+//! 1. disables the `teensy4-bsp`'s default features
+//! 2. enable the BSP's `"rtic"` feature
+//! 3. patch the `cortex-m-rt` crate with the Teensy 4's special runtime, available in
+//!    the `teensy4-bsp`'s repository.
+//!
+//! All three steps can be summarized by this `Cargo.toml` snippet:
+//!
+//! ```toml
+//! [dependencies.teensy4-bsp]
+//! git = "https://github.com/mciantyre/teensy4-rs"
+//! branch = "master"
+//! default-features = false
+//! features = ["rtic"]
+//!
+//! [patch.crates-io.cortex-m-rt]
+//! git = "https://github.com/mciantyre/teensy4-rs"
+//! branch = "master"
+//! ```
+//!
+//! You need to disable the BSP's default features, which disables the `"systick"` feature,
+//! to enable RTIC's SYSTICK handler. This means that you cannot use the USB logger when
+//! developing RTIC applications. Consider using the [`imxrt-uart-log`](https://crates.io/crates/imxrt-uart-log)
+//! crate for an alternate logging implementation.
+//!
+//! You need to replace the typical `cortex-m-rt` runtime with our custom runtime. The patch
+//! above lets us replace RTIC's runtime crate with an API-compatible runtime.
 //!
 //! ## Notice of alpha status
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,35 @@
 //!
 //! # Examples
 //!
+//! Turn on a Teensy 4.0's LED:
+//!
+//! ```no_run
+//! # #![feature(lang_items)]
+//! #![no_std]
+//! #![no_main]
+//!
+//! extern crate panic_halt;
+//!
+//! use bsp::rt::entry;
+//! use cortex_m::asm::wfi;
+//! use teensy4_bsp as bsp;
+//!
+//! use embedded_hal::digital::v2::OutputPin;
+//!
+//! #[entry]
+//! fn main() -> ! {
+//!     let peripherals = bsp::Peripherals::take().unwrap();
+//!     let pins = bsp::t40::pins(peripherals.iomuxc);
+//!     let mut led = bsp::configure_led(pins.p13);
+//!
+//!     loop {
+//!         led.set_high().unwrap();
+//!         wfi();
+//!     }
+//! }
+//! # #[lang = "eh_personality"] extern fn eh_personality() {}
+//! ```
+//!
 //! See the `teensy4-examples` crate for build-able, run-able
 //! examples. The examples utilize this BSP crate to blink LEDs,
 //! establish timers, and log data over USB.
@@ -57,6 +86,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Need to reference this so that it doesn't get stripped out
+#[cfg(target_arch = "arm")]
 extern crate teensy4_fcb;
 
 pub mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! If a user also registers a `SysTick` or `USB_OTG1` handler, it may
 //! result in a duplicate definition error.
 //!
-//! ## Re-exports
+//! # Re-exports
 //!
 //! The BSP re-exports the following:
 //!
@@ -40,7 +40,7 @@
 //! specific to the Teensy 4. See the `teensy4-fcb` crate for details
 //! on FCBs.
 //!
-//! ## Examples
+//! # Examples
 //!
 //! See the `teensy4-examples` crate for build-able, run-able
 //! examples. The examples utilize this BSP crate to blink LEDs,
@@ -59,7 +59,9 @@
 // Need to reference this so that it doesn't get stripped out
 extern crate teensy4_fcb;
 
+pub mod common;
 pub mod t40;
+pub mod t41;
 
 #[cfg(feature = "systick")]
 mod systick;
@@ -84,7 +86,7 @@ pub use imxrt_hal as hal;
 /// The LED
 ///
 /// See [`configure_led`](fn.configure_led.html) to prepare the LED.
-pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
+pub type LED = hal::gpio::GPIO<common::P13, hal::gpio::Output>;
 
 /// Configure the board's LED
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,58 +40,6 @@
 //! specific to the Teensy 4. See the `teensy4-fcb` crate for details
 //! on FCBs.
 //!
-//! ## Physical Pins to Pads and Alternative Functions
-//!
-//! The sparse table below describes the Teensy 4 pins, the pad ID, and some of the notable alternative functionalities
-//! for each pin. We add entries to the table as we add capabilities to the underlying HAL crate. Contributions to complete
-//! this table are welcome! If a pad's alternatives are not listed here, consult the iMXRT1060 reference manual.
-//!
-//! | Pin  | Pad ID   |  Alt0    |  Alt1        |  Alt2        |  Alt3     |  Alt4        |  Alt5            |  Alt6        |  Alt7   |  Alt8   |  Alt9   |
-//! | ---- | -------- | -------- | ------------ | ------------ | --------- | ------------ | ---------------- | ------------ | ------- | ------- | ------- |
-//! |  0   |`AD_B0_03`|          |              |  `UART6_RX`  |           |`FlexPWM1_1_X`|                  |              |         |         |         |
-//! |  1   |`AD_B0_02`|          |              |  `UART6_TX`  |           |`FlexPWM1_0_X`|                  |              |         |         |         |
-//! |  2   |`EMC_04`  |          |`FlexPWM4_2_A`|              |           |              |                  |              |         |         |         |
-//! |  3   |`EMC_05`  |          |`FlexPWM4_2_B`|              |           |              |                  |              |         |         |         |
-//! |  4   |`EMC_06`  |          |`FlexPWM2_0_A`|              |           |              |                  |              |         |         |         |
-//! |  5   |`EMC_08`  |          |`FlexPWM2_1_A`|              |           |              |                  |              |         |         |         |
-//! |  6   |`B0_10`   |          |              |`FlexPWM2_2_A`|           |              |                  |              |         |         |         |
-//! |  7   |`B1_01`   |          |              |  `UART4_RX`  |           |              |                  |`FlexPWM1_3_B`|         |         |         |
-//! |  8   |`B1_00`   |          |              |  `UART4_TX`  |           |              |                  |`FlexPWM1_3_A`|         |         |         |
-//! |  9   |`B0_11`   |          |              |`FlexPWM2_2_B`|           |              |                  |              |         |         |         |
-//! |  10  |`B0_00`   |          |              |              |`SPI4_PCS0`|              |                  |              |         |         |         |
-//! |  11  |`B0_02`   |          |              |              |`SPI4_SDO` |              |                  |              |         |         |         |
-//! |  12  |`B0_01`   |          |              |              |`SPI4_SDI` |              |                  |              |         |         |         |
-//! |  13  |`B0_03`   |          |              |              |`SPI4_SCK` |              |`GPIO2_3` (`LED`) |              |         |         |         |
-//! |  14  |`AD_B1_02`|          |              |  `UART2_TX`  |           |              |                  |              |         |         |         |
-//! |  15  |`AD_B1_03`|          |              |  `UART2_RX`  |           |              |                  |              |         |         |         |
-//! |  16  |`AD_B1_07`|          |`I2C3_SCL`    |  `UART3_RX`  |           |              |                  |              |         |         |         |
-//! |  17  |`AD_B1_06`|          |`I2C3_SDA`    |  `UART3_TX`  |           |              |                  |              |         |         |         |
-//! |  18  |`AD_B1_01`|          |              |              |`I2C1_SDA` |              |                  |              |         |         |         |
-//! |  19  |`AD_B1_00`|          |              |  `UART2_CTS` |`I2C1_SCL` |              |                  |              |         |         |         |
-//! |  20  |`AD_B1_10`|          |              |  `UART8_TX`  |           |              |                  |              |         |         |         |
-//! |  21  |`AD_B1_11`|          |              |  `UART8_RX`  |           |              |                  |              |         |         |         |
-//! |  22  |`AD_B1_08`|          |`FlexPWM4_0_A`|              |           |              |                  |              |         |         |         |
-//! |  23  |`AD_B1_09`|          |`FlexPWM4_1_A`|              |           |              |                  |              |         |         |         |
-//! |  24  |`AD_B0_12`|`I2C4_SCL`|              |  `UART1_TX`  |           |`FlexPWM1_2_X`|                  |              |         |         |         |
-//! |  25  |`AD_B0_13`|`I2C4_SDA`|              |  `UART1_RX`  |           |`FlexPWM1_3_X`|                  |              |         |         |         |
-//! |  26  |`AD_B1_14`|          |              |              |           |              |                  |              |         |         |         |
-//! |  27  |`AD_B1_15`|          |              |              |           |              |                  |              |         |         |         |
-//! |  28  |`EMC_32`  |          |`FlexPWM3_1_B`|  `UART7_RX`  |           |              |                  |              |         |         |         |
-//! |  29  |`EMC_31`  |          |`FlexPWM3_1_A`|  `UART7_TX`  |`SPI1_PCS1`|              |                  |              |         |         |         |
-//! |  30  |`EMC_37`  |          |              |              |           |              |                  |              |         |         |         |
-//! |  31  |`EMC_36`  |          |              |              |           |              |                  |              |         |         |         |
-//! |  32  |`B0_12`   |          |              |              |           |              |                  |              |         |         |         |
-//! |  33  |`EMC_07`  |          |`FlexPWM2_0_B`|              |           |              |                  |              |         |         |         |
-//! |  34  |`SD_B0_03`|          |`FlexPWM1_1_B`|              |           |  `SPI1_SDI`  |                  |              |         |         |         |
-//! |  35  |`SD_B0_02`|          |`FlexPWM1_1_A`|              |           |  `SPI1_SDO`  |                  |              |         |         |         |
-//! |  36  |`SD_B0_01`|          |`FlexPWM1_0_B`|  `I2C3_SDA`  |           |  `SPI1_PCS0` |                  |              |         |         |         |
-//! |  37  |`SD_B0_00`|          |`FlexPWM1_0_A`|  `I2C3_SCL`  |           |  `SPI1_SCK`  |                  |              |         |         |         |
-//! |  38  |`SD_B0_05`|          |`FlexPWM1_2_B`|  `UART8_RX`  |           |              |                  |              |         |         |         |
-//! |  39  |`SD_B0_04`|          |`FlexPWM1_2_A`|  `UART8_TX`  |           |              |                  |              |         |         |         |
-//!
-//! References:
-//! - [Teensy 4.0 Schematic Diagram](https://www.pjrc.com/teensy/schematic.html)
-//!
 //! ## Examples
 //!
 //! See the `teensy4-examples` crate for build-able, run-able
@@ -110,6 +58,8 @@
 // Need to reference this so that it doesn't get stripped out
 extern crate teensy4_fcb;
 
+pub mod t40;
+
 #[cfg(feature = "systick")]
 mod systick;
 #[cfg(feature = "usb-logging")]
@@ -117,6 +67,8 @@ pub mod usb;
 
 #[cfg(feature = "systick")]
 pub use systick::SysTick;
+#[cfg(feature = "usb-logging")]
+pub use usb::{init as usb_init, LoggingConfig};
 
 pub use hal::ral::interrupt;
 // `rtic` expects these in the root.
@@ -126,218 +78,10 @@ pub use hal::ral::{interrupt as Interrupt, NVIC_PRIO_BITS};
 pub use cortex_m_rt as rt;
 pub use imxrt_hal as hal;
 
+use hal::iomuxc;
+
 /// The LED in its final configuration
 pub type LED = hal::gpio::GPIO<iomuxc::b0::B0_03, hal::gpio::Output>;
-
-use hal::iomuxc;
-use iomuxc::consts::{U1, U2, U3, U4};
-
-/// Teensy pins that do not yet have a function
-///
-/// Pin 13 can be used for several things; one common usage is for the on-board LED.
-pub struct Pins {
-    /// Pin 0
-    pub p0: iomuxc::ad_b0::AD_B0_03,
-    /// Pin 1
-    pub p1: iomuxc::ad_b0::AD_B0_02,
-    /// Pin 2
-    pub p2: iomuxc::emc::EMC_04,
-    /// Pin 3
-    pub p3: iomuxc::emc::EMC_05,
-    /// Pin 4
-    pub p4: iomuxc::emc::EMC_06,
-    /// Pin 5
-    pub p5: iomuxc::emc::EMC_08,
-    /// Pin 6
-    pub p6: iomuxc::b0::B0_10,
-    /// Pin 7
-    pub p7: iomuxc::b1::B1_01,
-    /// Pin 8
-    pub p8: iomuxc::b1::B1_00,
-    /// Pin 9
-    pub p9: iomuxc::b0::B0_11,
-    /// Pin 10
-    pub p10: iomuxc::b0::B0_00,
-    /// Pin 11
-    pub p11: iomuxc::b0::B0_02,
-    /// Pin 12
-    pub p12: iomuxc::b0::B0_01,
-    /// Pin 13
-    pub p13: iomuxc::b0::B0_03,
-    /// Pin 14
-    pub p14: iomuxc::ad_b1::AD_B1_02,
-    /// Pin 15
-    pub p15: iomuxc::ad_b1::AD_B1_03,
-    /// Pin 16
-    pub p16: iomuxc::ad_b1::AD_B1_07,
-    /// Pin 17
-    pub p17: iomuxc::ad_b1::AD_B1_06,
-    /// Pin 18
-    pub p18: iomuxc::ad_b1::AD_B1_01,
-    /// Pin 19
-    pub p19: iomuxc::ad_b1::AD_B1_00,
-    /// Pin 20
-    pub p20: iomuxc::ad_b1::AD_B1_10,
-    /// Pin 21
-    pub p21: iomuxc::ad_b1::AD_B1_11,
-    /// Pin 22
-    pub p22: iomuxc::ad_b1::AD_B1_08,
-    /// Pin 23
-    pub p23: iomuxc::ad_b1::AD_B1_09,
-    /// Pin 24
-    pub p24: iomuxc::ad_b0::AD_B0_12,
-    /// Pin 25
-    pub p25: iomuxc::ad_b0::AD_B0_13,
-    /// Pin 28
-    pub p28: iomuxc::emc::EMC_32,
-    /// Pin 29
-    pub p29: iomuxc::emc::EMC_31,
-    /// Pin 33
-    pub p33: iomuxc::emc::EMC_07,
-    /// Pin 36
-    pub p36: iomuxc::sd_b0::SD_B0_01,
-    /// Pin 37
-    pub p37: iomuxc::sd_b0::SD_B0_00,
-}
-
-/// All peripherals available on the Teensy4
-///
-/// Nearly all of these are re-exports from the HAL. Exclusions include
-///
-/// - `usb`, which is a USB logger
-/// - `pins`, which are the Teensy 4's available pins
-///
-/// See the [module-level documentation](index.html) for more information.
-#[non_exhaustive]
-pub struct Peripherals {
-    /// Clock control module (forwarded from the HAL)
-    pub ccm: hal::ccm::CCM,
-    /// PIT timers (forwarded from the HAL)
-    pub pit: hal::pit::UnclockedPIT,
-    /// The USB logger and serial reader
-    #[cfg(feature = "usb-logging")]
-    pub usb: usb::USB,
-    /// DCDC converters
-    pub dcdc: hal::dcdc::DCDC,
-    /// PWM1 controller
-    pub pwm1: hal::pwm::Unclocked<U1>,
-    /// PWM2 controller
-    pub pwm2: hal::pwm::Unclocked<U2>,
-    /// PWM3 controller
-    pub pwm3: hal::pwm::Unclocked<U3>,
-    /// PWM4 controller
-    pub pwm4: hal::pwm::Unclocked<U4>,
-    /// Teensy pins
-    pub pins: Pins,
-    /// Unclocked I2C peripherals
-    pub i2c: hal::i2c::Unclocked,
-    /// Unclocked SPI peripherals
-    pub spi: hal::spi::Unclocked,
-    /// Unclocked UART peripherals
-    pub uart: hal::uart::Unclocked,
-    /// General purpose timer 1
-    pub gpt1: hal::gpt::Unclocked,
-    /// General purpose timer 2
-    pub gpt2: hal::gpt::Unclocked,
-    /// DMA channels
-    pub dma: hal::dma::Unclocked,
-    /// The SysTick delay timer
-    #[cfg(feature = "systick")]
-    pub systick: SysTick,
-}
-
-/// SYSTICK external clock frequency
-///
-/// See Section 12.3.2.1 of the reference manual. The note
-/// explains that the 24MHz clock is divided down to 100KHz
-/// before reaching SYSTICK.
-const SYSTICK_EXT_FREQ: u32 = 100_000;
-
-impl Peripherals {
-    /// Instantiate the system peripherals. This may only be called once!
-    pub fn take() -> Option<Self> {
-        let p = hal::Peripherals::take()?;
-        let mut cp = cortex_m::Peripherals::take()?;
-        Self::set_systick(&mut cp.SYST);
-        Some(Peripherals::new(p))
-    }
-
-    #[cfg(feature = "rtic")]
-    /// Steal all of the HAL's peripherals.
-    ///
-    /// # Safety
-    ///
-    /// NOTE: This constructor is only intended for use with the `rtic` crate. This is **not** an
-    /// alternative to the `take` constructor. The `take` constructor sets the system timer
-    /// interrupt while this constructor does not seeing as `rtic` will take care of this for us.
-    pub unsafe fn steal() -> Self {
-        Self::new(hal::Peripherals::steal())
-    }
-
-    fn set_systick(systick: &mut cortex_m::peripheral::SYST) {
-        systick.disable_counter();
-        systick.set_clock_source(cortex_m::peripheral::syst::SystClkSource::External);
-        systick.set_reload((SYSTICK_EXT_FREQ / 1000) - 1);
-        systick.clear_current();
-        systick.enable_counter();
-        systick.enable_interrupt();
-    }
-
-    fn new(p: hal::Peripherals) -> Peripherals {
-        Peripherals {
-            ccm: p.ccm,
-            pit: p.pit,
-            #[cfg(feature = "usb-logging")]
-            usb: usb::USB::new(),
-            dcdc: p.dcdc,
-            pwm1: p.pwm1,
-            pwm2: p.pwm2,
-            pwm3: p.pwm3,
-            pwm4: p.pwm4,
-            pins: Pins {
-                p0: p.iomuxc.ad_b0.p03,
-                p1: p.iomuxc.ad_b0.p02,
-                p2: p.iomuxc.emc.p04,
-                p3: p.iomuxc.emc.p05,
-                p4: p.iomuxc.emc.p06,
-                p5: p.iomuxc.emc.p08,
-                p6: p.iomuxc.b0.p10,
-                p7: p.iomuxc.b1.p01,
-                p8: p.iomuxc.b1.p00,
-                p9: p.iomuxc.b0.p11,
-                p10: p.iomuxc.b0.p00,
-                p11: p.iomuxc.b0.p02,
-                p12: p.iomuxc.b0.p01,
-                p13: p.iomuxc.b0.p03,
-                p14: p.iomuxc.ad_b1.p02,
-                p15: p.iomuxc.ad_b1.p03,
-                p16: p.iomuxc.ad_b1.p07,
-                p17: p.iomuxc.ad_b1.p06,
-                p18: p.iomuxc.ad_b1.p01,
-                p19: p.iomuxc.ad_b1.p00,
-                p20: p.iomuxc.ad_b1.p10,
-                p21: p.iomuxc.ad_b1.p11,
-                p22: p.iomuxc.ad_b1.p08,
-                p23: p.iomuxc.ad_b1.p09,
-                p24: p.iomuxc.ad_b0.p12,
-                p25: p.iomuxc.ad_b0.p13,
-                p28: p.iomuxc.emc.p32,
-                p29: p.iomuxc.emc.p31,
-                p33: p.iomuxc.emc.p07,
-                p36: p.iomuxc.sd_b0.p01,
-                p37: p.iomuxc.sd_b0.p00,
-            },
-            i2c: p.i2c,
-            spi: p.spi,
-            uart: p.uart,
-            gpt1: p.gpt1,
-            gpt2: p.gpt2,
-            dma: p.dma,
-            #[cfg(feature = "systick")]
-            systick: SysTick::new(),
-        }
-    }
-}
 
 /// Configure the board's LED
 ///

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -20,7 +20,7 @@ fn SysTick() {
 /// Read the systick counter. Returns an absolute value describing
 /// the number of milliseconds since the SYSTICK handler was enabled.
 /// This may be used to implement coarse timing.
-pub fn read() -> u32 {
+fn read() -> u32 {
     unsafe { core::ptr::read_volatile(&systick_millis_count) }
 }
 
@@ -44,15 +44,38 @@ pub extern "C" fn delay(millis: u32) {
     }
 }
 
+/// SYSTICK external clock frequency
+///
+/// See Section 12.3.2.1 of the reference manual. The note
+/// explains that the 24MHz clock is divided down to 100KHz
+/// before reaching SYSTICK.
+const SYSTICK_EXT_FREQ: u32 = 100_000;
+
 /// A type that represents the system timer, SYSTICK
 ///
 /// `SysTick` implements the `embedded_hal`'s `DelayMs` trait. It
 /// may be used to implement simple, blocking delays.
-pub struct SysTick(());
+pub struct SysTick(cortex_m::peripheral::SYST);
 
 impl SysTick {
-    pub(crate) fn new() -> Self {
-        SysTick(())
+    /// Convert the normal cortex-m SYST peripheral into a Teensy `SysTick`
+    ///
+    /// `new()` will configure the systick counter for a 1ms tick. When `new()` returns,
+    /// systick is counting.
+    ///
+    /// # Safety
+    ///
+    /// `new()` is safe because it assumes that it has the only `SYST` instance.
+    /// The only way you could acquire two `SysTick` is if you've unsafely obtained
+    /// a second `SYST` instance.
+    pub fn new(mut systick: cortex_m::peripheral::SYST) -> SysTick {
+        systick.disable_counter();
+        systick.set_clock_source(cortex_m::peripheral::syst::SystClkSource::External);
+        systick.set_reload((SYSTICK_EXT_FREQ / 1000) - 1);
+        systick.clear_current();
+        systick.enable_counter();
+        systick.enable_interrupt();
+        SysTick(systick)
     }
 
     /// Blocks for `ms` milliseconds

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -55,6 +55,7 @@ const SYSTICK_EXT_FREQ: u32 = 100_000;
 ///
 /// `SysTick` implements the `embedded_hal`'s `DelayMs` trait. It
 /// may be used to implement simple, blocking delays.
+#[cfg_attr(docsrs, doc(cfg(feature = "systick")))]
 pub struct SysTick(cortex_m::peripheral::SYST);
 
 impl SysTick {

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -55,6 +55,17 @@ const SYSTICK_EXT_FREQ: u32 = 100_000;
 ///
 /// `SysTick` implements the `embedded_hal`'s `DelayMs` trait. It
 /// may be used to implement simple, blocking delays.
+///
+/// # Example
+///
+/// ```no_run
+/// use teensy4_bsp as bsp;
+///
+/// let core_peripherals = cortex_m::Peripherals::take().unwrap();
+/// let mut systick = bsp::SysTick::new(core_peripherals.SYST);
+///
+/// systick.delay(50 /* ms */);
+/// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "systick")))]
 pub struct SysTick(cortex_m::peripheral::SYST);
 

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -26,11 +26,11 @@ fn read() -> u32 {
 
 /// Blocks for at least `millis` milliseconds
 ///
-/// `delay()` will spin-loop on updates from SYSTICK, until
+/// `delay` will spin-loop on updates from SYSTICK, until
 /// `millis` milliseconds have elapsed. SYSTICK has a 1ms
 /// interrupt interval, so the minimal delay is around 1ms.
 #[no_mangle]
-pub extern "C" fn delay(millis: u32) {
+extern "C" fn delay(millis: u32) {
     if 0 == millis {
         return;
     }
@@ -60,12 +60,12 @@ pub struct SysTick(cortex_m::peripheral::SYST);
 impl SysTick {
     /// Convert the normal cortex-m SYST peripheral into a Teensy `SysTick`
     ///
-    /// `new()` will configure the systick counter for a 1ms tick. When `new()` returns,
+    /// `new` will configure the systick counter for a 1ms tick. When `new()` returns,
     /// systick is counting.
     ///
     /// # Safety
     ///
-    /// `new()` is safe because it assumes that it has the only `SYST` instance.
+    /// `new` is safe because it assumes that it has the only `SYST` instance.
     /// The only way you could acquire two `SysTick` is if you've unsafely obtained
     /// a second `SYST` instance.
     pub fn new(mut systick: cortex_m::peripheral::SYST) -> SysTick {

--- a/src/t40.rs
+++ b/src/t40.rs
@@ -1,4 +1,4 @@
-//! Teensy 4.0 specific API
+//! Teensy 4.0 specific APIs
 //!
 //! # Pins unique to the Teensy 4.0
 //!
@@ -15,7 +15,7 @@
 //! |  39  |`SD_B0_04`|          |`FlexPWM1_2_A`|  `UART8_TX`  |           |              |                  |              |         |         |         |
 
 pub use crate::common::*;
-use crate::hal::iomuxc::sd_b0::*;
+use crate::hal::iomuxc::{sd_b0::*, ErasedPad};
 
 /// Pin 34 (4.0)
 pub type P34 = SD_B0_03;
@@ -29,6 +29,14 @@ pub type P37 = SD_B0_00;
 pub type P38 = SD_B0_05;
 /// Pin 39 (4.0)
 pub type P39 = SD_B0_04;
+
+/// Type-erased Teensy 4.0 pins
+///
+/// To get pin 13, the LED, index into the 13th element of this array:
+/// `erased_pins[13]`.
+///
+/// Use [`Pins::erase`] to erase pin types.
+pub type ErasedPins = [ErasedPad; 40];
 
 /// Teensy 4.0 pins
 ///
@@ -162,5 +170,54 @@ pub fn pins(iomuxc: crate::hal::iomuxc::Pads) -> Pins {
         p37: iomuxc.sd_b0.p00,
         p38: iomuxc.sd_b0.p05,
         p39: iomuxc.sd_b0.p04,
+    }
+}
+
+impl Pins {
+    /// Erase the types of all pins
+    pub fn erase(self) -> ErasedPins {
+        [
+            self.p0.erase(),
+            self.p1.erase(),
+            self.p2.erase(),
+            self.p3.erase(),
+            self.p4.erase(),
+            self.p5.erase(),
+            self.p6.erase(),
+            self.p7.erase(),
+            self.p8.erase(),
+            self.p9.erase(),
+            self.p10.erase(),
+            self.p11.erase(),
+            self.p12.erase(),
+            self.p13.erase(),
+            self.p14.erase(),
+            self.p15.erase(),
+            self.p16.erase(),
+            self.p17.erase(),
+            self.p18.erase(),
+            self.p19.erase(),
+            self.p20.erase(),
+            self.p21.erase(),
+            self.p22.erase(),
+            self.p23.erase(),
+            self.p24.erase(),
+            self.p25.erase(),
+            self.p26.erase(),
+            self.p27.erase(),
+            self.p28.erase(),
+            self.p29.erase(),
+            self.p30.erase(),
+            self.p31.erase(),
+            self.p32.erase(),
+            self.p33.erase(),
+            // END OF COMMON PINS
+            self.p34.erase(),
+            self.p35.erase(),
+            self.p36.erase(),
+            self.p37.erase(),
+            self.p38.erase(),
+            self.p39.erase(),
+        ]
     }
 }

--- a/src/t40.rs
+++ b/src/t40.rs
@@ -2,7 +2,7 @@
 //!
 //! # Pins unique to the Teensy 4.0
 //!
-//! See the [`common` documentation](../common/index.html) for pins that are consistent
+//! See the [`common` module](../common/index.html) for pins that are consistent
 //! across both boards.
 //!
 //! | Pin  | Pad ID   |  Alt0    |  Alt1        |  Alt2        |  Alt3     |  Alt4        |  Alt5            |  Alt6        |  Alt7   |  Alt8   |  Alt9   |
@@ -35,7 +35,7 @@ pub type P39 = SD_B0_04;
 /// To get pin 13, the LED, index into the 13th element of this array:
 /// `erased_pins[13]`.
 ///
-/// Use [`Pins::erase`] to erase pin types.
+/// Use [`Pins::erase`](struct.Pins.html#method.erase) to erase pin types.
 pub type ErasedPins = [ErasedPad; 40];
 
 /// Teensy 4.0 pins

--- a/src/t40.rs
+++ b/src/t40.rs
@@ -13,6 +13,16 @@
 //! |  37  |`SD_B0_00`|          |`FlexPWM1_0_A`|  `I2C3_SCL`  |           |  `SPI1_SCK`  |                  |              |         |         |         |
 //! |  38  |`SD_B0_05`|          |`FlexPWM1_2_B`|  `UART8_RX`  |           |              |                  |              |         |         |         |
 //! |  39  |`SD_B0_04`|          |`FlexPWM1_2_A`|  `UART8_TX`  |           |              |                  |              |         |         |         |
+//!
+//! # Example: get Teensy 4.0 pins
+//!
+//! ```no_run
+//! use teensy4_bsp as bsp;
+//!
+//! let peripherals = bsp::Peripherals::take().unwrap();
+//! let pins = bsp::t40::pins(peripherals.iomuxc);
+//! let led = bsp::configure_led(pins.p13);
+//! ```
 
 pub use crate::common::*;
 use crate::hal::iomuxc::{sd_b0::*, ErasedPad};

--- a/src/t40.rs
+++ b/src/t40.rs
@@ -1,0 +1,223 @@
+//! Teensy 4.0 specific API
+//!
+//! ## Pins, Pads and Alternates
+//!
+//! The sparse table below describes the Teensy 4 pins, the pad ID, and some of the notable alternate functionalities
+//! for each pin. We add entries to the table as we add capabilities to the underlying HAL crate. If a pad's alternates
+//! are not listed here, consult the iMXRT1060 reference manual.
+//!
+//! | Pin  | Pad ID   |  Alt0    |  Alt1        |  Alt2        |  Alt3     |  Alt4        |  Alt5            |  Alt6        |  Alt7   |  Alt8   |  Alt9   |
+//! | ---- | -------- | -------- | ------------ | ------------ | --------- | ------------ | ---------------- | ------------ | ------- | ------- | ------- |
+//! |  0   |`AD_B0_03`|          |              |  `UART6_RX`  |           |`FlexPWM1_1_X`|                  |              |         |         |         |
+//! |  1   |`AD_B0_02`|          |              |  `UART6_TX`  |           |`FlexPWM1_0_X`|                  |              |         |         |         |
+//! |  2   |`EMC_04`  |          |`FlexPWM4_2_A`|              |           |              |                  |              |         |         |         |
+//! |  3   |`EMC_05`  |          |`FlexPWM4_2_B`|              |           |              |                  |              |         |         |         |
+//! |  4   |`EMC_06`  |          |`FlexPWM2_0_A`|              |           |              |                  |              |         |         |         |
+//! |  5   |`EMC_08`  |          |`FlexPWM2_1_A`|              |           |              |                  |              |         |         |         |
+//! |  6   |`B0_10`   |          |              |`FlexPWM2_2_A`|           |              |                  |              |         |         |         |
+//! |  7   |`B1_01`   |          |              |  `UART4_RX`  |           |              |                  |`FlexPWM1_3_B`|         |         |         |
+//! |  8   |`B1_00`   |          |              |  `UART4_TX`  |           |              |                  |`FlexPWM1_3_A`|         |         |         |
+//! |  9   |`B0_11`   |          |              |`FlexPWM2_2_B`|           |              |                  |              |         |         |         |
+//! |  10  |`B0_00`   |          |              |              |`SPI4_PCS0`|              |                  |              |         |         |         |
+//! |  11  |`B0_02`   |          |              |              |`SPI4_SDO` |              |                  |              |         |         |         |
+//! |  12  |`B0_01`   |          |              |              |`SPI4_SDI` |              |                  |              |         |         |         |
+//! |  13  |`B0_03`   |          |              |              |`SPI4_SCK` |              |`GPIO2_3` (`LED`) |              |         |         |         |
+//! |  14  |`AD_B1_02`|          |              |  `UART2_TX`  |           |              |                  |              |         |         |         |
+//! |  15  |`AD_B1_03`|          |              |  `UART2_RX`  |           |              |                  |              |         |         |         |
+//! |  16  |`AD_B1_07`|          |`I2C3_SCL`    |  `UART3_RX`  |           |              |                  |              |         |         |         |
+//! |  17  |`AD_B1_06`|          |`I2C3_SDA`    |  `UART3_TX`  |           |              |                  |              |         |         |         |
+//! |  18  |`AD_B1_01`|          |              |              |`I2C1_SDA` |              |                  |              |         |         |         |
+//! |  19  |`AD_B1_00`|          |              |  `UART2_CTS` |`I2C1_SCL` |              |                  |              |         |         |         |
+//! |  20  |`AD_B1_10`|          |              |  `UART8_TX`  |           |              |                  |              |         |         |         |
+//! |  21  |`AD_B1_11`|          |              |  `UART8_RX`  |           |              |                  |              |         |         |         |
+//! |  22  |`AD_B1_08`|          |`FlexPWM4_0_A`|              |           |              |                  |              |         |         |         |
+//! |  23  |`AD_B1_09`|          |`FlexPWM4_1_A`|              |           |              |                  |              |         |         |         |
+//! |  24  |`AD_B0_12`|`I2C4_SCL`|              |  `UART1_TX`  |           |`FlexPWM1_2_X`|                  |              |         |         |         |
+//! |  25  |`AD_B0_13`|`I2C4_SDA`|              |  `UART1_RX`  |           |`FlexPWM1_3_X`|                  |              |         |         |         |
+//! |  26  |`AD_B1_14`|          |              |              |           |              |                  |              |         |         |         |
+//! |  27  |`AD_B1_15`|          |              |              |           |              |                  |              |         |         |         |
+//! |  28  |`EMC_32`  |          |`FlexPWM3_1_B`|  `UART7_RX`  |           |              |                  |              |         |         |         |
+//! |  29  |`EMC_31`  |          |`FlexPWM3_1_A`|  `UART7_TX`  |`SPI1_PCS1`|              |                  |              |         |         |         |
+//! |  30  |`EMC_37`  |          |              |              |           |              |                  |              |         |         |         |
+//! |  31  |`EMC_36`  |          |              |              |           |              |                  |              |         |         |         |
+//! |  32  |`B0_12`   |          |              |              |           |              |                  |              |         |         |         |
+//! |  33  |`EMC_07`  |          |`FlexPWM2_0_B`|              |           |              |                  |              |         |         |         |
+//! |  34  |`SD_B0_03`|          |`FlexPWM1_1_B`|              |           |  `SPI1_SDI`  |                  |              |         |         |         |
+//! |  35  |`SD_B0_02`|          |`FlexPWM1_1_A`|              |           |  `SPI1_SDO`  |                  |              |         |         |         |
+//! |  36  |`SD_B0_01`|          |`FlexPWM1_0_B`|  `I2C3_SDA`  |           |  `SPI1_PCS0` |                  |              |         |         |         |
+//! |  37  |`SD_B0_00`|          |`FlexPWM1_0_A`|  `I2C3_SCL`  |           |  `SPI1_SCK`  |                  |              |         |         |         |
+//! |  38  |`SD_B0_05`|          |`FlexPWM1_2_B`|  `UART8_RX`  |           |              |                  |              |         |         |         |
+//! |  39  |`SD_B0_04`|          |`FlexPWM1_2_A`|  `UART8_TX`  |           |              |                  |              |         |         |         |
+//!
+//! References:
+//! - [Teensy 4.0 Schematic Diagram](https://www.pjrc.com/teensy/schematic.html)
+
+use crate::hal::iomuxc;
+
+/// Pin 0
+pub type P0 = iomuxc::ad_b0::AD_B0_03;
+/// Pin 1
+pub type P1 = iomuxc::ad_b0::AD_B0_02;
+/// Pin 2
+pub type P2 = iomuxc::emc::EMC_04;
+/// Pin 3
+pub type P3 = iomuxc::emc::EMC_05;
+/// Pin 4
+pub type P4 = iomuxc::emc::EMC_06;
+/// Pin 5
+pub type P5 = iomuxc::emc::EMC_08;
+/// Pin 6
+pub type P6 = iomuxc::b0::B0_10;
+/// Pin 7
+pub type P7 = iomuxc::b1::B1_01;
+/// Pin 8
+pub type P8 = iomuxc::b1::B1_00;
+/// Pin 9
+pub type P9 = iomuxc::b0::B0_11;
+/// Pin 10
+pub type P10 = iomuxc::b0::B0_00;
+/// Pin 11
+pub type P11 = iomuxc::b0::B0_02;
+/// Pin 12
+pub type P12 = iomuxc::b0::B0_01;
+/// Pin 13
+pub type P13 = iomuxc::b0::B0_03;
+/// Pin 14
+pub type P14 = iomuxc::ad_b1::AD_B1_02;
+/// Pin 15
+pub type P15 = iomuxc::ad_b1::AD_B1_03;
+/// Pin 16
+pub type P16 = iomuxc::ad_b1::AD_B1_07;
+/// Pin 17
+pub type P17 = iomuxc::ad_b1::AD_B1_06;
+/// Pin 18
+pub type P18 = iomuxc::ad_b1::AD_B1_01;
+/// Pin 19
+pub type P19 = iomuxc::ad_b1::AD_B1_00;
+/// Pin 20
+pub type P20 = iomuxc::ad_b1::AD_B1_10;
+/// Pin 21
+pub type P21 = iomuxc::ad_b1::AD_B1_11;
+/// Pin 22
+pub type P22 = iomuxc::ad_b1::AD_B1_08;
+/// Pin 23
+pub type P23 = iomuxc::ad_b1::AD_B1_09;
+/// Pin 24
+pub type P24 = iomuxc::ad_b0::AD_B0_12;
+/// Pin 25
+pub type P25 = iomuxc::ad_b0::AD_B0_13;
+/// Pin 28
+pub type P28 = iomuxc::emc::EMC_32;
+/// Pin 29
+pub type P29 = iomuxc::emc::EMC_31;
+/// Pin 33
+pub type P33 = iomuxc::emc::EMC_07;
+/// Pin 36
+pub type P36 = iomuxc::sd_b0::SD_B0_01;
+/// Pin 37
+pub type P37 = iomuxc::sd_b0::SD_B0_00;
+
+/// Teensy 4.0 pins
+///
+/// Pin 13 can be used for several things; one common usage is for the on-board LED.
+pub struct Pins {
+    /// Pin 0
+    pub p0: P0,
+    /// Pin 1
+    pub p1: P1,
+    /// Pin 2
+    pub p2: P2,
+    /// Pin 3
+    pub p3: P3,
+    /// Pin 4
+    pub p4: P4,
+    /// Pin 5
+    pub p5: P5,
+    /// Pin 6
+    pub p6: P6,
+    /// Pin 7
+    pub p7: P7,
+    /// Pin 8
+    pub p8: P8,
+    /// Pin 9
+    pub p9: P9,
+    /// Pin 10
+    pub p10: P10,
+    /// Pin 11
+    pub p11: P11,
+    /// Pin 12
+    pub p12: P12,
+    /// Pin 13
+    pub p13: P13,
+    /// Pin 14
+    pub p14: P14,
+    /// Pin 15
+    pub p15: P15,
+    /// Pin 16
+    pub p16: P16,
+    /// Pin 17
+    pub p17: P17,
+    /// Pin 18
+    pub p18: P18,
+    /// Pin 19
+    pub p19: P19,
+    /// Pin 20
+    pub p20: P20,
+    /// Pin 21
+    pub p21: P21,
+    /// Pin 22
+    pub p22: P22,
+    /// Pin 23
+    pub p23: P23,
+    /// Pin 24
+    pub p24: P24,
+    /// Pin 25
+    pub p25: P25,
+    /// Pin 28
+    pub p28: P28,
+    /// Pin 29
+    pub p29: P29,
+    /// Pin 33
+    pub p33: P33,
+    /// Pin 36
+    pub p36: P36,
+    /// Pin 37
+    pub p37: P37,
+}
+
+/// Constrain the processor pads to the Teensy 4.0 pins
+pub fn pins(iomuxc: crate::hal::iomuxc::Pads) -> Pins {
+    Pins {
+        p0: iomuxc.ad_b0.p03,
+        p1: iomuxc.ad_b0.p02,
+        p2: iomuxc.emc.p04,
+        p3: iomuxc.emc.p05,
+        p4: iomuxc.emc.p06,
+        p5: iomuxc.emc.p08,
+        p6: iomuxc.b0.p10,
+        p7: iomuxc.b1.p01,
+        p8: iomuxc.b1.p00,
+        p9: iomuxc.b0.p11,
+        p10: iomuxc.b0.p00,
+        p11: iomuxc.b0.p02,
+        p12: iomuxc.b0.p01,
+        p13: iomuxc.b0.p03,
+        p14: iomuxc.ad_b1.p02,
+        p15: iomuxc.ad_b1.p03,
+        p16: iomuxc.ad_b1.p07,
+        p17: iomuxc.ad_b1.p06,
+        p18: iomuxc.ad_b1.p01,
+        p19: iomuxc.ad_b1.p00,
+        p20: iomuxc.ad_b1.p10,
+        p21: iomuxc.ad_b1.p11,
+        p22: iomuxc.ad_b1.p08,
+        p23: iomuxc.ad_b1.p09,
+        p24: iomuxc.ad_b0.p12,
+        p25: iomuxc.ad_b0.p13,
+        p28: iomuxc.emc.p32,
+        p29: iomuxc.emc.p31,
+        p33: iomuxc.emc.p07,
+        p36: iomuxc.sd_b0.p01,
+        p37: iomuxc.sd_b0.p00,
+    }
+}

--- a/src/t41.rs
+++ b/src/t41.rs
@@ -1,4 +1,4 @@
-//! Teensy 4.1 specific API
+//! Teensy 4.1 specific APIs
 //!
 //! # Pins unique to the Teensy 4.1
 //!
@@ -17,7 +17,7 @@
 //! |  41  |`AD_B1_05`|          |              |              |           |              |                  |              |         |         |         |
 
 pub use crate::common::*;
-use crate::hal::iomuxc::{ad_b1::*, b1::*};
+use crate::hal::iomuxc::{ad_b1::*, b1::*, ErasedPad};
 
 /// Pin 34 (4.1)
 pub type P34 = B1_13;
@@ -35,6 +35,14 @@ pub type P39 = AD_B1_13;
 pub type P40 = AD_B1_04;
 /// Pin 41 (4.1)
 pub type P41 = AD_B1_05;
+
+/// Type-erased Teensy 4.1 pins
+///
+/// To get pin 13, the LED, index into the 13th element of this array:
+/// `erased_pins[13]`.
+///
+/// Use [`Pins::erase`] to erase pin types.
+pub type ErasedPins = [ErasedPad; 42];
 
 /// Teensy 4.1 pins
 ///
@@ -174,5 +182,56 @@ pub fn pins(iomuxc: crate::hal::iomuxc::Pads) -> Pins {
         p39: iomuxc.ad_b1.p13,
         p40: iomuxc.ad_b1.p04,
         p41: iomuxc.ad_b1.p05,
+    }
+}
+
+impl Pins {
+    /// Erase the types of all pins
+    pub fn erase(self) -> ErasedPins {
+        [
+            self.p0.erase(),
+            self.p1.erase(),
+            self.p2.erase(),
+            self.p3.erase(),
+            self.p4.erase(),
+            self.p5.erase(),
+            self.p6.erase(),
+            self.p7.erase(),
+            self.p8.erase(),
+            self.p9.erase(),
+            self.p10.erase(),
+            self.p11.erase(),
+            self.p12.erase(),
+            self.p13.erase(),
+            self.p14.erase(),
+            self.p15.erase(),
+            self.p16.erase(),
+            self.p17.erase(),
+            self.p18.erase(),
+            self.p19.erase(),
+            self.p20.erase(),
+            self.p21.erase(),
+            self.p22.erase(),
+            self.p23.erase(),
+            self.p24.erase(),
+            self.p25.erase(),
+            self.p26.erase(),
+            self.p27.erase(),
+            self.p28.erase(),
+            self.p29.erase(),
+            self.p30.erase(),
+            self.p31.erase(),
+            self.p32.erase(),
+            self.p33.erase(),
+            // END OF COMMON PINS
+            self.p34.erase(),
+            self.p35.erase(),
+            self.p36.erase(),
+            self.p37.erase(),
+            self.p38.erase(),
+            self.p39.erase(),
+            self.p40.erase(),
+            self.p41.erase(),
+        ]
     }
 }

--- a/src/t41.rs
+++ b/src/t41.rs
@@ -2,7 +2,7 @@
 //!
 //! # Pins unique to the Teensy 4.1
 //!
-//! See the [`common` documentation](../common/index.html) for pins that are consistent
+//! See the [`common` module](../common/index.html) for pins that are consistent
 //! across both boards.
 //!
 //! | Pin  | Pad ID   |  Alt0    |  Alt1        |  Alt2        |  Alt3     |  Alt4        |  Alt5            |  Alt6        |  Alt7   |  Alt8   |  Alt9   |
@@ -41,7 +41,7 @@ pub type P41 = AD_B1_05;
 /// To get pin 13, the LED, index into the 13th element of this array:
 /// `erased_pins[13]`.
 ///
-/// Use [`Pins::erase`] to erase pin types.
+/// Use [`Pins::erase`](struct.Pins.html#method.erase) to erase pin types.
 pub type ErasedPins = [ErasedPad; 42];
 
 /// Teensy 4.1 pins

--- a/src/t41.rs
+++ b/src/t41.rs
@@ -1,39 +1,45 @@
-//! Teensy 4.0 specific API
+//! Teensy 4.1 specific API
 //!
-//! # Pins unique to the Teensy 4.0
+//! # Pins unique to the Teensy 4.1
 //!
 //! See the [`common` documentation](../common/index.html) for pins that are consistent
 //! across both boards.
 //!
 //! | Pin  | Pad ID   |  Alt0    |  Alt1        |  Alt2        |  Alt3     |  Alt4        |  Alt5            |  Alt6        |  Alt7   |  Alt8   |  Alt9   |
 //! | ---- | -------- | -------- | ------------ | ------------ | --------- | ------------ | ---------------- | ------------ | ------- | ------- | ------- |
-//! |  34  |`SD_B0_03`|          |`FlexPWM1_1_B`|              |           |  `SPI1_SDI`  |                  |              |         |         |         |
-//! |  35  |`SD_B0_02`|          |`FlexPWM1_1_A`|              |           |  `SPI1_SDO`  |                  |              |         |         |         |
-//! |  36  |`SD_B0_01`|          |`FlexPWM1_0_B`|  `I2C3_SDA`  |           |  `SPI1_PCS0` |                  |              |         |         |         |
-//! |  37  |`SD_B0_00`|          |`FlexPWM1_0_A`|  `I2C3_SCL`  |           |  `SPI1_SCK`  |                  |              |         |         |         |
-//! |  38  |`SD_B0_05`|          |`FlexPWM1_2_B`|  `UART8_RX`  |           |              |                  |              |         |         |         |
-//! |  39  |`SD_B0_04`|          |`FlexPWM1_2_A`|  `UART8_TX`  |           |              |                  |              |         |         |         |
+//! |  34  |`B1_13`   |          |              |              |           |              |                  |              |         |         |         |
+//! |  35  |`B1_12`   |          |              |              |           |              |                  |              |         |         |         |
+//! |  36  |`B1_02`   |          |              |              |           |              |                  |              |         |         |         |
+//! |  37  |`B1_03`   |          |              |              |           |              |                  |              |         |         |         |
+//! |  38  |`AD_B1_12`|          |              |              |           |              |                  |              |         |         |         |
+//! |  39  |`AD_B1_13`|          |              |              |           |              |                  |              |         |         |         |
+//! |  40  |`AD_B1_04`|          |              |              |           |              |                  |              |         |         |         |
+//! |  41  |`AD_B1_05`|          |              |              |           |              |                  |              |         |         |         |
 
 pub use crate::common::*;
-use crate::hal::iomuxc::sd_b0::*;
+use crate::hal::iomuxc::{ad_b1::*, b1::*};
 
-/// Pin 34 (4.0)
-pub type P34 = SD_B0_03;
-/// Pin 35 (4.0)
-pub type P35 = SD_B0_02;
-/// Pin 36 (4.0)
-pub type P36 = SD_B0_01;
-/// Pin 37 (4.0)
-pub type P37 = SD_B0_00;
-/// Pin 38 (4.0)
-pub type P38 = SD_B0_05;
-/// Pin 39 (4.0)
-pub type P39 = SD_B0_04;
+/// Pin 34 (4.1)
+pub type P34 = B1_13;
+/// Pin 35 (4.1)
+pub type P35 = B1_12;
+/// Pin 36 (4.1)
+pub type P36 = B1_02;
+/// Pin 37 (4.1)
+pub type P37 = B1_03;
+/// Pin 38 (4.1)
+pub type P38 = AD_B1_12;
+/// Pin 39 (4.1)
+pub type P39 = AD_B1_13;
+/// Pin 40 (4.1)
+pub type P40 = AD_B1_04;
+/// Pin 41 (4.1)
+pub type P41 = AD_B1_05;
 
-/// Teensy 4.0 pins
+/// Teensy 4.1 pins
 ///
 /// See [`pins`](fn.pins.html) to constrain the processor's pads, and acquire
-/// Teensy 4.0 pins.
+/// Teensy 4.1 pins.
 pub struct Pins {
     /// Pin 0
     pub p0: P0,
@@ -116,9 +122,13 @@ pub struct Pins {
     pub p38: P38,
     /// Pin 39
     pub p39: P39,
+    /// Pin 40
+    pub p40: P40,
+    /// Pin 41
+    pub p41: P41,
 }
 
-/// Constrain the processor pads to the Teensy 4.0 pins
+/// Constrain the processor pads to the Teensy 4.1 pins
 pub fn pins(iomuxc: crate::hal::iomuxc::Pads) -> Pins {
     Pins {
         p0: iomuxc.ad_b0.p03,
@@ -156,11 +166,13 @@ pub fn pins(iomuxc: crate::hal::iomuxc::Pads) -> Pins {
         p32: iomuxc.b0.p12,
         p33: iomuxc.emc.p07,
         // END OF COMMON PINS
-        p34: iomuxc.sd_b0.p03,
-        p35: iomuxc.sd_b0.p02,
-        p36: iomuxc.sd_b0.p01,
-        p37: iomuxc.sd_b0.p00,
-        p38: iomuxc.sd_b0.p05,
-        p39: iomuxc.sd_b0.p04,
+        p34: iomuxc.b1.p13,
+        p35: iomuxc.b1.p12,
+        p36: iomuxc.b1.p02,
+        p37: iomuxc.b1.p03,
+        p38: iomuxc.ad_b1.p12,
+        p39: iomuxc.ad_b1.p13,
+        p40: iomuxc.ad_b1.p04,
+        p41: iomuxc.ad_b1.p05,
     }
 }

--- a/src/t41.rs
+++ b/src/t41.rs
@@ -15,6 +15,16 @@
 //! |  39  |`AD_B1_13`|          |              |              |           |              |                  |              |         |         |         |
 //! |  40  |`AD_B1_04`|          |              |              |           |              |                  |              |         |         |         |
 //! |  41  |`AD_B1_05`|          |              |              |           |              |                  |              |         |         |         |
+//!
+//! # Example
+//!
+//! ```no_run
+//! use teensy4_bsp as bsp;
+//!
+//! let peripherals = bsp::Peripherals::take().unwrap();
+//! let pins = bsp::t41::pins(peripherals.iomuxc);
+//! let led = bsp::configure_led(pins.p13);
+//! ```
 
 pub use crate::common::*;
 use crate::hal::iomuxc::{ad_b1::*, b1::*, ErasedPad};

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -34,7 +34,7 @@
 //!
 //! let core_peripherals = cortex_m::Peripherals::take().unwrap();
 //! let mut systick = bsp::SysTick::new(core_peripherals.SYST);
-//! let (mut reader, mut writer) = bsp::usb::split().unwrap();
+//! let (mut reader, mut writer) = bsp::usb::split(&systick).unwrap();
 //!
 //! write!(writer, "Hello world! 3 + 2 = {}", 5);
 //! ```
@@ -129,7 +129,7 @@ pub fn init(_: &crate::SysTick, config: LoggingConfig) -> Result<Reader, Error> 
     Ok(Reader(core::marker::PhantomData))
 }
 
-pub fn split() -> Result<(Reader, Writer), Error> {
+pub fn split(_: &crate::SysTick) -> Result<(Reader, Writer), Error> {
     let taken = TAKEN.swap(true, Ordering::SeqCst);
     if taken {
         return Err(Error::AlreadySet);

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -6,6 +6,38 @@
 //! [`log`] crate to write data over USB.
 //!
 //! [`log`]: https://crates.io/crates/log
+//!
+//! # Logging Example
+//!
+//! ```no_run
+//! use teensy4_bsp as bsp;
+//!
+//! let core_peripherals = cortex_m::Peripherals::take().unwrap();
+//! let mut systick = bsp::SysTick::new(core_peripherals.SYST);
+//! bsp::usb::init(
+//!     &systick,
+//!     bsp::usb::LoggingConfig {
+//!         filters: &[("motor", None)],
+//!         ..Default::default()
+//!     },
+//! )
+//! .unwrap();
+//!
+//! log::info!("Hello world! 3 + 2 = {}", 5);
+//! ```
+//!
+//! # Reader / Writer Example
+//!
+//! ```no_run
+//! use teensy4_bsp as bsp;
+//! use core::fmt::Write;
+//!
+//! let core_peripherals = cortex_m::Peripherals::take().unwrap();
+//! let mut systick = bsp::SysTick::new(core_peripherals.SYST);
+//! let (mut reader, mut writer) = bsp::usb::split().unwrap();
+//!
+//! write!(writer, "Hello world! 3 + 2 = {}", 5);
+//! ```
 
 use crate::interrupt; // bring in interrupt variants for #[interrupt] macro
 use core::{

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -3,8 +3,7 @@
 //! The USB stack provides a [`log`] implementation for logging over USB
 //!
 //! This is `Serial.println()` in Rust. Use the macros of the
-//! [`log`] crate to write data over USB. Messages can be read
-//! back using `screen` or `PuTTY`.
+//! [`log`] crate to write data over USB.
 //!
 //! [`log`]: https://crates.io/crates/log
 
@@ -24,7 +23,7 @@ use teensy4_usb_sys as usbsys;
 /// Set the `filters` collection to specify log targets of interest.
 ///
 /// If the default configuration is good for you, use `Default::default()`
-/// as the argument to `init()`.
+/// as the argument to [`init`](fn.init.html).
 pub struct LoggingConfig {
     /// The max log level
     ///


### PR DESCRIPTION
The PR demonstrates how we could support both Teensy 4.0 and 4.1 boards from a single BSP. This has breaking changes. See #69 for details.

This work is based on the `iomuxc-integration` branch. To keep the diff relevant, this PR target that branch.