### PR TITLE
Add API documentation to repo

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,5 +1,6 @@
 status = [
     "clippy",
+    "doc",
     "format",
     "precompiled",
     "template"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,35 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches: [ master, staging, trying ]
+
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    container:
+      image: rustops/crates-build-env:latest
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      name: Install toolchain
+      with:
+        toolchain: nightly
+        target: thumbv7em-none-eabihf
+        override: true
+
+    - name: Generate docs
+      run: cargo rustdoc --all-features -- --cfg docsrs
+
+    - name: Write redirect
+      run: echo "<meta http-equiv=\"refresh\" content=\"0;url=teensy4_bsp\">" > target/thumbv7em-none-eabihf/doc/index.html
+
+    - name: Deploy to GitHub pages
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: target/thumbv7em-none-eabihf/doc
+        publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We've measured a few things things, like I2C, UART, SPI, and timer timings. No o
 
 ![Code Checks](https://github.com/mciantyre/teensy4-rs/workflows/Code%20Checks/badge.svg)
 
+#### [API Docs](https://mciantyre.github.io/teensy4-rs/)
+
 ## Dependencies
 
 - A Rust installation; recommended installation using `rustup`. We support the latest, stable Rust toolchain.


### PR DESCRIPTION
The BSP isn't available on crates.io, so we can't get the benefits of docs.rs documentation generation. But, we can publish documentation from the repo. The PR adds a job to publish the BSP's documentation to GH pages.