### PR TITLE
Patch a future cortex-m-rt crate

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -6,6 +6,9 @@ name: Check Template
 on:
   push:
     branches: [ master, staging, trying ]
+  schedule:
+    # At 15:28 on a Thursday
+    - cron: "28 15 * * 4"
 
 jobs:
   template:

--- a/cortex-m-rt-patch/Cargo.toml
+++ b/cortex-m-rt-patch/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cortex-m-rt"
-version = "0.6.12"
+version = "0.6.999+teensy4"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
12 days ago, the embedded Rust team released version 0.6.13 of the `cortex-m-rt` crate. Because our `cortex-m-rt-patch` crate was versioned at 0.6.12, it would not patch the latest runtime crate. This resulted in a [broken build](https://github.com/mciantyre/teensy4-rs/runs/1138151669?check_suite_focus=true#step:4:86) for anyone who has started using the BSP since the `cortex-m-rt` release.

This PR updates our patch crate so that it may patch any 0.6 version of the `cortex-m-rt` crate (within reason).