### PR TITLE
Disable low-power wait mode during startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,13 @@ RTIC_EXAMPLES := $(shell ls -1 examples | grep rtic | cut -f 1 -d .)
 
 .PHONY: all
 all:
+	@cargo build --examples $(MODE)
 	@for example in $(EXAMPLES);\
-		do cargo objcopy $(MODE) --example $$example \
-			-- -O ihex $(TARGET_EXAMPLES)/$$example.hex;\
+		do rust-objcopy -O ihex $(TARGET_EXAMPLES)/$$example $(TARGET_EXAMPLES)/$$example.hex;\
 		done
+	@cargo build --examples $(MODE) --no-default-features --features=rtic
 	@for example in $(RTIC_EXAMPLES);\
-		do cargo objcopy $(MODE) --example $$example \
-			--no-default-features --features=rtic \
-			-- -O ihex $(TARGET_EXAMPLES)/$$example.hex;\
+		do rust-objcopy -O ihex $(TARGET_EXAMPLES)/$$example $(TARGET_EXAMPLES)/$$example.hex;\
 		done
 
 # Build all RTIC-related examples

--- a/examples/pit.rs
+++ b/examples/pit.rs
@@ -63,11 +63,6 @@ fn main() -> ! {
 
     let (_, _, _, mut timer) = periphs.pit.clock(&mut cfg);
 
-    // Chip might stop running if we hit WFI out of reset too fast.
-    // So, block for 500ms, then drop into our loop.
-    timer.start(core::time::Duration::from_millis(500));
-    while timer.wait().is_err() {}
-
     timer.set_interrupt_enable(true);
     unsafe {
         TIMER = Some(timer);

--- a/examples/rtic_blink.rs
+++ b/examples/rtic_blink.rs
@@ -28,18 +28,6 @@ const APP: () = {
     fn init(mut cx: init::Context) -> init::LateResources {
         init_delay();
 
-        // Set the clock mode to 'RUN'
-        //
-        // i.MX RT (106x) processors will not wake on SYSTICK. When we enter
-        // WFI or WFE, we'll enter WAIT mode by default. This will disable
-        // SYSTICK. So, if you're waiting for SYSTICK to wake you up, it won't
-        // happen. By setting ourselves to 'RUN' low-power mode, SYSTICK will
-        // still wake us up.
-        //
-        // See the CCM_CLPCR register for more information. The HAL docs also note
-        // this aspect of the processor.
-        cx.device.ccm.set_mode(bsp::hal::ccm::ClockMode::Run);
-
         // Initialise the monotonic CYCCNT timer.
         cx.core.DWT.enable_cycle_counter();
 

--- a/examples/rtic_blink.rs
+++ b/examples/rtic_blink.rs
@@ -26,8 +26,6 @@ const APP: () = {
 
     #[init(schedule = [blink])]
     fn init(mut cx: init::Context) -> init::LateResources {
-        init_delay();
-
         // Initialise the monotonic CYCCNT timer.
         cx.core.DWT.enable_cycle_counter();
 
@@ -62,14 +60,3 @@ const APP: () = {
         fn LPUART8();
     }
 };
-
-// If we reach WFI on teensy 4.0 too quickly it seems to halt. Here we wait a short while in `init`
-// to avoid this issue. The issue only appears to occur when rebooting the device (via the button),
-// however there appears to be no issue when power cycling the device.
-//
-// TODO: Investigate exactly why this appears to be necessary.
-fn init_delay() {
-    for _ in 0..10_000_000 {
-        core::sync::atomic::spin_loop_hint();
-    }
-}

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -55,8 +55,6 @@ const APP: () = {
 
     #[init(schedule = [blink])]
     fn init(mut cx: init::Context) -> init::LateResources {
-        init_delay();
-
         cx.core.DWT.enable_cycle_counter();
         cx.device.ccm.pll1.set_arm_clock(
             bsp::hal::ccm::PLL1::ARM_HZ,
@@ -156,14 +154,3 @@ const APP: () = {
         fn LPUART8();
     }
 };
-
-// If we reach WFI on teensy 4.0 too quickly it seems to halt. Here we wait a short while in `init`
-// to avoid this issue. The issue only appears to occur when rebooting the device (via the button),
-// however there appears to be no issue when power cycling the device.
-//
-// TODO: Investigate exactly why this appears to be necessary.
-fn init_delay() {
-    for _ in 0..10_000_000 {
-        core::sync::atomic::spin_loop_hint();
-    }
-}

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -57,8 +57,6 @@ const APP: () = {
     fn init(mut cx: init::Context) -> init::LateResources {
         init_delay();
 
-        // Setup the clock for rtic scheduling.
-        cx.device.ccm.set_mode(bsp::hal::ccm::ClockMode::Run);
         cx.core.DWT.enable_cycle_counter();
         cx.device.ccm.pll1.set_arm_clock(
             bsp::hal::ccm::PLL1::ARM_HZ,

--- a/examples/rtic_uart_log.rs
+++ b/examples/rtic_uart_log.rs
@@ -50,8 +50,6 @@ const APP: () = {
     fn init(mut cx: init::Context) -> init::LateResources {
         init_delay();
 
-        // Setup the clock for rtic scheduling.
-        cx.device.ccm.set_mode(bsp::hal::ccm::ClockMode::Run);
         cx.core.DWT.enable_cycle_counter();
         cx.device.ccm.pll1.set_arm_clock(
             bsp::hal::ccm::PLL1::ARM_HZ,

--- a/examples/rtic_uart_log.rs
+++ b/examples/rtic_uart_log.rs
@@ -48,8 +48,6 @@ const APP: () = {
 
     #[init(schedule = [blink])]
     fn init(mut cx: init::Context) -> init::LateResources {
-        init_delay();
-
         cx.core.DWT.enable_cycle_counter();
         cx.device.ccm.pll1.set_arm_clock(
             bsp::hal::ccm::PLL1::ARM_HZ,
@@ -137,14 +135,3 @@ const APP: () = {
         fn LPUART8();
     }
 };
-
-// If we reach WFI on teensy 4.0 too quickly it seems to halt. Here we wait a short while in `init`
-// to avoid this issue. The issue only appears to occur when rebooting the device (via the button),
-// however there appears to be no issue when power cycling the device.
-//
-// TODO: Investigate exactly why this appears to be necessary.
-fn init_delay() {
-    for _ in 0..10_000_000 {
-        core::sync::atomic::spin_loop_hint();
-    }
-}

--- a/teensy4-rt/link.x
+++ b/teensy4-rt/link.x
@@ -63,7 +63,6 @@ SECTIONS
         LONG(0x00000000);           /* Plugin flag (unused) */
         /* --------- */
         KEEP(*(.boot.reset));
-        KEEP(*(.boot.tcm));
         KEEP(*(.HardFaultTrampoline));
         KEEP(*(.HardFault.*));
         /* Contains the reset vectors, exceptions, and interrupts. */


### PR DESCRIPTION
Set the low-power state to run mode, rather than keeping the default wait mode. Seems to mitigate #76. Tested on the `led.rs` example.

The PR also moves the vector table into DTCM. Now, interrupt handles will be found in memory, and no longer require an address lookup in off-board FLASH.