### PR TITLE
Add SRTC example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 */target/*
 **/*.rs.bk
 Cargo.lock
+/.idea
 /out
 /svd/imxrt1062/*
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,15 @@ path = "cortex-m-rt-patch"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+# Temporary patch for testing SRTC feature
+[patch.crates-io.imxrt-hal]
+git = "https://github.com/AlyoshaVasilieva/imxrt-rs"
+rev = "621b103"
+
+[patch.crates-io.imxrt-iomuxc]
+git = "https://github.com/AlyoshaVasilieva/imxrt-rs"
+rev = "621b103"
+
 ##########
 # Examples
 ##########
@@ -146,6 +155,10 @@ required-features = ["usb-logging"]
 
 [[example]]
 name = "spi"
+required-features = ["usb-logging"]
+
+[[example]]
+name = "srtc"
 required-features = ["usb-logging"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,12 +99,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 # Temporary patch for testing SRTC feature
 [patch.crates-io.imxrt-hal]
-git = "https://github.com/AlyoshaVasilieva/imxrt-rs"
-rev = "621b103"
+git = "https://github.com/imxrt-rs/imxrt-rs"
+rev = "a85b279"
 
 [patch.crates-io.imxrt-iomuxc]
-git = "https://github.com/AlyoshaVasilieva/imxrt-rs"
-rev = "621b103"
+git = "https://github.com/imxrt-rs/imxrt-rs"
+rev = "a85b279"
 
 ##########
 # Examples

--- a/examples/srtc.rs
+++ b/examples/srtc.rs
@@ -1,0 +1,93 @@
+//! Demonstrates using the SRTC, including setting time from USB serial.
+//!
+//! Flash this example to your Teensy, then send the current Unix time over the USB serial port.
+//!
+//! Send either just the seconds, e.g. `1601896065`, or seconds.nanos, e.g. `1601896065.068985800`.
+//! The whole message must be sent at once; typing it will take the first digit as the time.
+//!
+//! On a GNU system, for example: `date +%s.%N >> /dev/ttyS5` (where `ttyS5` is the serial port
+//! of the Teensy 4)
+//!
+//! On Windows, try pasting the Unix time into the serial window.
+//!
+//! On any host platform, use `SystemTime` to get the Unix time:
+//!
+//! ```no_run
+//! use std::time::SystemTime;
+//!
+//! let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
+//! let seconds = now.as_secs();
+//! let ns = now.subsec_nanos();
+//! let message = format!("{}.{:09}", seconds, ns);
+//! ```
+//!
+//! and then send that message using a crate that provides support for serial port communication.
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use bsp::hal::srtc::{micros_to_ticks, EnabledState, SRTC};
+use bsp::rt;
+use bsp::usb;
+use core::fmt::Write;
+use teensy4_bsp as bsp;
+
+#[rt::entry]
+fn main() -> ! {
+    let mut p = bsp::Peripherals::take().unwrap();
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    let (mut reader, mut writer) = bsp::usb::split(&systick).unwrap();
+    systick.delay(2000);
+    p.ccm
+        .pll1
+        .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
+    let srtc = match p.srtc.try_enable(&mut p.ccm.handle, 0, 0) {
+        EnabledState::AlreadyCounting { srtc, seconds, .. } => {
+            writeln!(writer, "SRTC already on, counting from {}", seconds).unwrap();
+            srtc
+        }
+        EnabledState::SetTime(mut srtc) => {
+            // SRTC wasn't on, request time from USB
+            set_time_from_usb(&mut systick, &mut reader, &mut writer, &mut srtc);
+            srtc
+        }
+    };
+    let mut now = srtc.get();
+    loop {
+        writeln!(writer, "The current Unix time is {}", now).unwrap();
+        while now == srtc.get() {}
+        now = srtc.get();
+    }
+}
+
+fn set_time_from_usb(
+    systick: &mut bsp::SysTick,
+    reader: &mut usb::Reader,
+    writer: &mut usb::Writer,
+    rtc: &mut SRTC,
+) {
+    writeln!(writer, "Send a message containing the current Unix time.").unwrap();
+    let mut buffer = [0; 24]; // 20 char message + CR LF + an extra 2
+    let (seconds, ns) = loop {
+        systick.delay(10);
+        let count = reader.read(&mut buffer);
+        if count == 0 {
+            continue;
+        }
+        if let Ok(message) = core::str::from_utf8(&buffer[..count]) {
+            let mut split = message.trim_end().split('.');
+            if let Some(seconds) = split.next() {
+                if let Ok(seconds) = seconds.parse::<u32>() {
+                    let ns = split.next().unwrap_or("0");
+                    let ns = ns.parse::<u32>().unwrap_or(0);
+                    break (seconds, ns);
+                }
+            }
+        }
+    };
+    let us = ns / 1000;
+    let ticks = micros_to_ticks(us);
+    rtc.set(seconds, ticks);
+}


### PR DESCRIPTION
Adds an example for the SRTC using https://github.com/imxrt-rs/imxrt-rs/pull/83, based on your prototype example.

I believe this is more-or-less a realistic example of basic usage. I'll change this as necessary if I need to make any changes to the imxrt-hal SRTC support.