### PR TITLE
Add docs, tests, around USB log filtering; add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add `teensy4_bsp::usb::Filter` type alias to simplify USB filter definitions
+
+## [0.1.0] - 2020-10-16
+
+First release of `teensy4-bsp` to crates.io.
+
+[0.1.0]: https://github.com/mciantyre/teensy4-rs/releases/tag/teensy4-bsp-0.1.0

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ clean:
 # still work.
 .PHONY: test
 test:
-	@cargo +nightly test --lib --tests --target $(HOST) --no-default-features --features systick
+	@cargo +nightly test --lib --tests --target $(HOST)
 	@cargo +nightly test --doc --target $(HOST) --all-features
 
 	@cargo +nightly test --manifest-path teensy4-pins/Cargo.toml --lib --tests --target $(HOST) --all-features

--- a/examples/bsp/src/bin/usb.rs
+++ b/examples/bsp/src/bin/usb.rs
@@ -13,6 +13,20 @@ extern crate panic_halt;
 use cortex_m_rt as rt;
 use teensy4_bsp as bsp;
 
+/// Specify (optional) logging filters
+///
+/// The "usb" filter matches the name of this example.
+/// If you copy and paste this example somewhere else,
+/// consider updating the filter, or removing the filter
+/// entirely.
+///
+/// See the `LoggingConfig` documentation for more information.
+const LOG_FILTERS: &[bsp::usb::Filter] = &[
+    // +------------- Module name to include in log messages
+    // v     v------- Maximum log level (subject to the statically-defined max level)
+    ("usb", None),
+];
+
 #[rt::entry]
 fn main() -> ! {
     let mut p = bsp::Peripherals::take().unwrap();
@@ -22,7 +36,7 @@ fn main() -> ! {
     let mut usb_reader = bsp::usb::init(
         &systick,
         bsp::usb::LoggingConfig {
-            filters: &[("usb", None)],
+            filters: LOG_FILTERS,
             ..Default::default()
         },
     )

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -46,6 +46,10 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 mod bindings;
+mod filters;
+
+pub use filters::Filter;
+use filters::Filters;
 
 /// Logging configuration
 ///
@@ -69,7 +73,7 @@ pub struct LoggingConfig {
     /// If set to an empty slice (default), the logger performs no
     /// filtering. Otherwise, we filter the specified targets by
     /// the accompanying log level. If there is no level, we default
-    pub filters: &'static [(&'static str, Option<::log::LevelFilter>)],
+    pub filters: &'static [Filter],
 }
 
 impl Default for LoggingConfig {
@@ -119,7 +123,7 @@ pub fn init(_: &crate::SysTick, config: LoggingConfig) -> Result<Reader, Error> 
     }
     unsafe {
         LOGGER.enabled = true;
-        LOGGER.filters = config.filters;
+        LOGGER.filters = Filters::new(config.filters);
 
         ::log::set_logger(&LOGGER).map(|_| ::log::set_max_level(config.max_level))?;
         start();
@@ -161,39 +165,19 @@ struct Logger {
     enabled: bool,
     /// A collection of targets that we are expected
     /// to filter. If this is empty, we allow everything
-    filters: &'static [(&'static str, Option<::log::LevelFilter>)],
-}
-
-impl Logger {
-    /// Returns true if the target is in the filter, else false if the target is
-    /// not in the list of kept targets. If the filter collection is empty, return
-    /// true.
-    fn filtered(&self, metadata: &::log::Metadata) -> bool {
-        if self.filters.is_empty() {
-            true
-        } else if let Some(idx) = self
-            .filters
-            .iter()
-            .position(|&(target, _)| target == metadata.target())
-        {
-            let (_, lvl) = self.filters[idx];
-            lvl.is_none() || lvl.filter(|lvl| metadata.level() <= *lvl).is_some()
-        } else {
-            false
-        }
-    }
+    filters: Filters,
 }
 
 static mut LOGGER: Logger = Logger {
     enabled: false,
-    filters: &[],
+    filters: Filters::empty(),
 };
 
 impl ::log::Log for Logger {
     fn enabled(&self, metadata: &::log::Metadata) -> bool {
         self.enabled // We're enabled
             && metadata.level() <= ::log::max_level() // The log level is appropriate
-            && self.filtered(metadata) // The target is in the filter list
+            && self.filters.is_enabled(metadata) // The target is in the filter list
     }
 
     fn log(&self, record: &::log::Record) {

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -3,7 +3,8 @@
 //! The USB stack provides a [`log`] implementation for logging over USB
 //!
 //! This is `Serial.println()` in Rust. Use the macros of the
-//! [`log`] crate to write data over USB.
+//! [`log`] crate to write data over USB. Or, acquire a raw [`Reader`]
+//! and [`Writer`] to perform your own USB I/O.
 //!
 //! [`log`]: https://crates.io/crates/log
 //!
@@ -131,6 +132,7 @@ pub fn init(_: &crate::SysTick, config: LoggingConfig) -> Result<Reader, Error> 
     Ok(Reader(core::marker::PhantomData))
 }
 
+/// Splits the USB stack into reading and writing halves, and returns both halves
 pub fn split(_: &crate::SysTick) -> Result<(Reader, Writer), Error> {
     let taken = TAKEN.swap(true, Ordering::SeqCst);
     if taken {

--- a/src/usb/bindings.rs
+++ b/src/usb/bindings.rs
@@ -35,7 +35,7 @@
 //! We define the attributes in the build script, specifing the
 //! macro values in the command-line compiler invocation.
 
-#[link(name = "t4usb")]
+#[cfg_attr(target_arch = "arm", link(name = "t4usb"))]
 extern "C" {
     /// Initialize the USB PLL and clocks.
     ///

--- a/src/usb/filters.rs
+++ b/src/usb/filters.rs
@@ -1,0 +1,131 @@
+//! Logging filters
+
+/// Filter log messages by module name (`&'static str`) to a log level
+///
+/// - if the level is `None`, log at all levels from the module (subject to the max log level)
+/// - if the level is not `None`, that will be the base log level for the module
+///
+/// # Example
+///
+/// ```
+/// use teensy4_bsp as bsp;
+/// use bsp::usb::Filter;
+/// use log::LevelFilter;
+///
+/// static LEVELS: &'static [Filter] = &[
+///     // Writes messages from the 'i2c' module subject to the max log level
+///     ("i2c", None),
+///     // Writes only Error- and Warn-level messages from the 'spi' module
+///     ("spi", Some(LevelFilter::Warn)),
+/// ];
+/// ```
+pub type Filter = (&'static str, Option<::log::LevelFilter>);
+
+/// Filters for log channels
+pub struct Filters(&'static [Filter]);
+
+impl Filters {
+    /// Returns an empty filters collection
+    ///
+    /// This `Filters` lets all log messages pass through.
+    pub const fn empty() -> Self {
+        Filters::new(&[])
+    }
+
+    /// Create a `Filters` collection
+    pub const fn new(filters: &'static [Filter]) -> Self {
+        Filters(filters)
+    }
+}
+
+impl Filters {
+    /// Returns `true` if, based on this metadata, logging should be enabled
+    ///
+    /// `is_enabled()` considers the permitted modules and log levels for those modules.
+    pub fn is_enabled(&self, metadata: &::log::Metadata) -> bool {
+        if self.0.is_empty() {
+            true
+        } else if let Some(idx) = self
+            .0
+            .iter()
+            .position(|&(target, _)| target == metadata.target())
+        {
+            let (_, lvl) = self.0[idx];
+            lvl.is_none() || lvl.filter(|lvl| metadata.level() <= *lvl).is_some()
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Filters;
+    use log::{Level, LevelFilter};
+
+    fn metadata(level: Level, target: &'static str) -> ::log::Metadata<'static> {
+        ::log::Metadata::builder()
+            .level(level)
+            .target(target)
+            .build()
+    }
+
+    const ALL_LEVELS: [Level; 5] = [
+        Level::Error,
+        Level::Warn,
+        Level::Info,
+        Level::Debug,
+        Level::Trace,
+    ];
+
+    #[test]
+    fn empty_always_enabled() {
+        let filters = Filters(&[]);
+        ALL_LEVELS.iter().for_each(|level| {
+            assert!(filters.is_enabled(&metadata(*level, "foobar")));
+        });
+    }
+
+    #[test]
+    fn no_level_always_true() {
+        let filters = Filters(&[("barbaz", None), ("foobar", None)]);
+        ALL_LEVELS
+            .iter()
+            .for_each(|level| assert!(filters.is_enabled(&metadata(*level, "foobar"))));
+    }
+
+    #[test]
+    fn module_level() {
+        let filters = Filters(&[
+            ("barbaz", Some(LevelFilter::Error)),
+            ("foobar", Some(LevelFilter::Info)),
+        ]);
+        ALL_LEVELS
+            .iter()
+            .filter(|level| **level <= LevelFilter::Info)
+            .for_each(|level| {
+                assert!(filters.is_enabled(&metadata(*level, "foobar")), "{}", level)
+            });
+        ALL_LEVELS
+            .iter()
+            .filter(|level| **level > LevelFilter::Info)
+            .for_each(|level| {
+                assert!(
+                    !filters.is_enabled(&metadata(*level, "foobar")),
+                    "{}",
+                    level
+                )
+            });
+        ALL_LEVELS
+            .iter()
+            .filter(|level| **level != Level::Error)
+            .for_each(|level| {
+                assert!(
+                    !filters.is_enabled(&metadata(*level, "barbaz")),
+                    "{}",
+                    level
+                )
+            });
+        assert!(filters.is_enabled(&metadata(Level::Error, "barbaz")));
+    }
+}


### PR DESCRIPTION
The PR stresses that the USB logging example is using a log filter, and that it may not as-is for your work. There's some small refactoring within the USB logging module to support testing, and simplify filter definitions.

Additionally,

- update the build to support cross-platform unit testing
- add a CHANGELOG