### PR TITLE
Add teensy4-panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ panic-halt = "0.2.0"
 members = [
     "examples/bsp",
     "teensy4-fcb",
+    "teensy4-panic",
     "teensy4-pins",
 ]
 

--- a/examples/bsp/Cargo.toml
+++ b/examples/bsp/Cargo.toml
@@ -10,13 +10,16 @@ version = "0.1"
 path = "../../"
 features = ["rt"]
 
+[dependencies.teensy4-panic]
+version = "0.1"
+path = "../../teensy4-panic"
+
 [dependencies]
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.13"
 embedded-hal = "0.2.4"
 log = "0.4.8"
 nb = "0.1.2"
-panic-halt = "0.2.0"
 
 # Examples that don't need any features
 
@@ -30,6 +33,10 @@ required-features = []
 
 [[bin]]
 name = "pit"
+required-features = []
+
+[[bin]]
+name = "panic"
 required-features = []
 
 # Examples that use SYSTICK as a timer

--- a/examples/bsp/src/bin/dma_memcpy.rs
+++ b/examples/bsp/src/bin/dma_memcpy.rs
@@ -6,7 +6,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::dma;
 use core::iter::ExactSizeIterator;

--- a/examples/bsp/src/bin/dma_memcpy.rs
+++ b/examples/bsp/src/bin/dma_memcpy.rs
@@ -47,9 +47,7 @@ fn main() -> ! {
         Ok(buffer) => buffer,
         Err(error) => {
             log::error!("Unable to create the transfer buffer: {:?}", error);
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
     };
 
@@ -57,9 +55,7 @@ fn main() -> ! {
         Ok(buffer) => buffer,
         Err(error) => {
             log::error!("Unable to create the receive buffer: {:?}", error);
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
     };
 
@@ -76,9 +72,7 @@ fn main() -> ! {
 
         if let Err(error) = memcpy.transfer(tx_buffer, rx_buffer) {
             log::error!("Unable to start memcpy: {:?}", error);
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         } else {
             log::info!("Transfer started...");
         }
@@ -97,9 +91,7 @@ fn main() -> ! {
             }
             None => {
                 log::error!("Memcpy didn't give us back the buffers!");
-                loop {
-                    core::sync::atomic::spin_loop_hint();
-                }
+                panic!();
             }
         };
 

--- a/examples/bsp/src/bin/dma_spi.rs
+++ b/examples/bsp/src/bin/dma_spi.rs
@@ -106,9 +106,7 @@ fn prepare_transfer(spi: &mut SpiDma) {
         if let dma::Error::Setup(es) = err {
             log::error!("{}", es);
         }
-        loop {
-            core::sync::atomic::spin_loop_hint();
-        }
+        panic!();
     }
 
     if let Err((_, err)) = spi.start_transfer(tx_buffer) {
@@ -117,9 +115,7 @@ fn prepare_transfer(spi: &mut SpiDma) {
             log::error!("{}", es);
         }
         spi.receive_cancel();
-        loop {
-            core::sync::atomic::spin_loop_hint();
-        }
+        panic!();
     }
 }
 
@@ -135,9 +131,7 @@ fn take_buffers() -> (TxBuffer, RxBuffer) {
             tx_buffer.is_none(),
             rx_buffer.is_none()
         );
-        loop {
-            core::sync::atomic::spin_loop_hint();
-        }
+        panic!();
     }
 
     (tx_buffer.unwrap(), rx_buffer.unwrap())
@@ -206,9 +200,7 @@ fn main() -> ! {
                 SPI_BAUD_RATE_HZ,
                 err
             );
-            loop {
-                core::sync::atomic::spin_loop_hint()
-            }
+            panic!();
         }
     };
 
@@ -249,17 +241,13 @@ fn main() -> ! {
         };
         if tx_buffer_mut(prep_tx).is_none() {
             log::error!("Cannot prepare transfer buffer");
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
 
         let prep_rx = |rx: &mut dma::Linear<u16>| rx.set_transfer_len(1);
         if rx_buffer_mut(prep_rx).is_none() {
             log::error!("Cannot prepare receive buffer");
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
         systick.delay(500);
 
@@ -278,9 +266,7 @@ fn main() -> ! {
                     }
                 } else {
                     log::error!("RX buffer was inaccessible!");
-                    loop {
-                        core::sync::atomic::spin_loop_hint();
-                    }
+                    panic!();
                 }
             }
         }
@@ -298,9 +284,7 @@ fn main() -> ! {
         };
         if tx_buffer_mut(set_tx_buf).is_none() {
             log::error!("Unable to modify transfer buffer!");
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
 
         let set_rx_buf = |rx: &mut dma::Linear<u16>| {
@@ -308,9 +292,7 @@ fn main() -> ! {
         };
         if rx_buffer_mut(set_rx_buf).is_none() {
             log::error!("Unable to modify receive buffer!");
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
 
         systick.delay(500);

--- a/examples/bsp/src/bin/dma_spi.rs
+++ b/examples/bsp/src/bin/dma_spi.rs
@@ -26,7 +26,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::dma;
 use bsp::interrupt;

--- a/examples/bsp/src/bin/dma_uart.rs
+++ b/examples/bsp/src/bin/dma_uart.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::interrupt;
 use cortex_m_rt::entry;

--- a/examples/bsp/src/bin/dma_uart.rs
+++ b/examples/bsp/src/bin/dma_uart.rs
@@ -127,9 +127,7 @@ fn main() -> ! {
         let mut rx_buffer = match free(|cs| RX_BUFFER.borrow(cs).borrow_mut().take()) {
             None => {
                 log::error!("No receive buffer!");
-                loop {
-                    core::sync::atomic::spin_loop_hint();
-                }
+                panic!();
             }
             Some(rx_buffer) => rx_buffer,
         };
@@ -139,9 +137,7 @@ fn main() -> ! {
         let res = dma_uart.start_receive(rx_buffer);
         if let Err(err) = res {
             log::error!("Error scheduling DMA receive: {:?}", err);
-            loop {
-                core::sync::atomic::spin_loop_hint();
-            }
+            panic!();
         }
 
         loop {
@@ -162,9 +158,7 @@ fn main() -> ! {
                 let mut tx_buffer = match free(|cs| TX_BUFFER.borrow(cs).borrow_mut().take()) {
                     None => {
                         log::error!("No transfer buffer!");
-                        loop {
-                            core::sync::atomic::spin_loop_hint();
-                        }
+                        panic!();
                     }
                     Some(tx_buffer) => tx_buffer,
                 };
@@ -174,9 +168,7 @@ fn main() -> ! {
                 let res = dma_uart.start_transfer(tx_buffer);
                 if let Err(err) = res {
                     log::warn!("Error scheduling DMA transfer: {:?}", err);
-                    loop {
-                        core::sync::atomic::spin_loop_hint();
-                    }
+                    panic!();
                 }
             } else if TX_READY.load(Ordering::Acquire) {
                 continue 'start;

--- a/examples/bsp/src/bin/gpt.rs
+++ b/examples/bsp/src/bin/gpt.rs
@@ -6,7 +6,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::gpt;
 use bsp::interrupt;

--- a/examples/bsp/src/bin/i2c.rs
+++ b/examples/bsp/src/bin/i2c.rs
@@ -17,7 +17,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::i2c::ClockSpeed;
 use embedded_hal::blocking::i2c;

--- a/examples/bsp/src/bin/led.rs
+++ b/examples/bsp/src/bin/led.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use cortex_m::asm::wfi;
 use cortex_m_rt::entry;

--- a/examples/bsp/src/bin/panic.rs
+++ b/examples/bsp/src/bin/panic.rs
@@ -1,0 +1,17 @@
+//! Demonstrates the panic handler
+
+#![no_std]
+#![no_main]
+
+use teensy4_bsp as bsp;
+use teensy4_panic as _;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let mut p = bsp::Peripherals::take().unwrap();
+    p.ccm
+        .pll1
+        .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
+
+    panic!();
+}

--- a/examples/bsp/src/bin/pit.rs
+++ b/examples/bsp/src/bin/pit.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::pit;
 use bsp::interrupt;

--- a/examples/bsp/src/bin/pwm.rs
+++ b/examples/bsp/src/bin/pwm.rs
@@ -13,7 +13,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::pwm::Channel;
 use cortex_m_rt as rt;

--- a/examples/bsp/src/bin/spi.rs
+++ b/examples/bsp/src/bin/spi.rs
@@ -21,7 +21,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use cortex_m_rt::entry;
 use teensy4_bsp as bsp;

--- a/examples/bsp/src/bin/srtc.rs
+++ b/examples/bsp/src/bin/srtc.rs
@@ -26,7 +26,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use core::fmt::Write;
 

--- a/examples/bsp/src/bin/systick.rs
+++ b/examples/bsp/src/bin/systick.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use cortex_m_rt as rt;
 use teensy4_bsp as bsp;

--- a/examples/bsp/src/bin/timer.rs
+++ b/examples/bsp/src/bin/timer.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use bsp::hal::pit;
 use cortex_m_rt::entry;

--- a/examples/bsp/src/bin/uart.rs
+++ b/examples/bsp/src/bin/uart.rs
@@ -18,7 +18,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use cortex_m_rt::entry;
 use teensy4_bsp as bsp;

--- a/examples/bsp/src/bin/usb.rs
+++ b/examples/bsp/src/bin/usb.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use cortex_m_rt as rt;
 use teensy4_bsp as bsp;

--- a/examples/bsp/src/bin/usb_writer.rs
+++ b/examples/bsp/src/bin/usb_writer.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use teensy4_panic as _;
 
 use core::fmt::Write;
 use cortex_m_rt as rt;

--- a/teensy4-panic/Cargo.toml
+++ b/teensy4-panic/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/mciantyre/teensy4-rs"
 description = """
-Panic handler for Teensy 4 systems.
+Panic handler for the Teensy 4.
 Part of the teensy4-rs project.
 """
 categories = [

--- a/teensy4-panic/Cargo.toml
+++ b/teensy4-panic/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "teensy4-panic"
+version = "0.1.0"
+authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
+edition = "2018"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/mciantyre/teensy4-rs"
+description = """
+Panic handler for Teensy 4 systems.
+Part of the teensy4-rs project.
+"""
+categories = [
+    "embedded",
+    "hardware-support",
+    "no-std",
+]
+keywords = [
+    "arm",
+    "cortex-m",
+    "teensy4",
+]

--- a/teensy4-panic/LICENSE-APACHE
+++ b/teensy4-panic/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/teensy4-panic/LICENSE-MIT
+++ b/teensy4-panic/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Ian McIntyre
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/teensy4-panic/README.md
+++ b/teensy4-panic/README.md
@@ -1,0 +1,26 @@
+# teensy4-panic
+
+Panic handler for the Teensy 4
+
+When you link `teensy4-panic` into your program, any `panic!()` will cause
+your Teensy's LED to blink S.O.S. in Morse code. Supports both Teensy 4.0 and
+4.1 boards.
+
+## Usage
+
+Depend on `teensy4-panic`:
+
+```toml
+[dependencies]
+teensy4-panic = # ...
+```
+
+Then, include the crate in your final program:
+
+```rust
+use teensy4_panic as _;
+```
+
+Finally, use `panic!()` to stop the program, and blink the LED.
+
+License: MIT OR Apache-2.0

--- a/teensy4-panic/src/lib.rs
+++ b/teensy4-panic/src/lib.rs
@@ -1,0 +1,90 @@
+//! Panic handler for Teensy 4 systems
+
+#![no_std]
+
+/// The LED
+struct LED();
+
+const GPIO2_BASE: u32 = 0x401BC000;
+
+impl LED {
+    /// Construct the LED
+    ///
+    /// When `new` returns, the LED will be ready to set, clear, and toggle.
+    fn new() -> Self {
+        const IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_03: *mut u32 = 0x401F_8148 as *mut u32;
+        const IOMUXC_SW_PAD_CTL_PAD_GPIO_B0_03: *mut u32 = 0x401F_8338 as *mut u32;
+        const IOMUXC_GPR_GPR27: *mut u32 = 0x400A_C06C as *mut u32;
+
+        const fn drive_strength_enable(dse: u32) -> u32 {
+            (dse & 0x07) << 3
+        }
+
+        const GPIO2_GDIR: *mut u32 = (GPIO2_BASE + 0x04) as *mut u32;
+
+        // Safety: this modifies IOMUXC memory that may be configured for another
+        // peripheral. But, this is a panic handler, and we're not returning from
+        // this state.
+        unsafe {
+            // Set the LED pad into Alt5
+            IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_03.write_volatile(5);
+            // Increase drive strength, clearing all other fields
+            IOMUXC_SW_PAD_CTL_PAD_GPIO_B0_03.write_volatile(drive_strength_enable(7));
+            // Disable fast mode so that GPIO2 registers drive the pad
+            IOMUXC_GPR_GPR27.write_volatile(IOMUXC_GPR_GPR27.read_volatile() & !(1 << 3));
+            GPIO2_GDIR.write_volatile(GPIO2_GDIR.read_volatile() | (1 << 3))
+        }
+
+        LED()
+    }
+
+    /// Drive the LED high
+    fn set(&mut self) {
+        const GPIO2_DR_SET: *mut u32 = (GPIO2_BASE + 0x84) as *mut u32;
+        // Safety: modify global peripheral memory, but no one will ever notice
+        // since we don't return from the panic handler
+        unsafe { GPIO2_DR_SET.write_volatile(1 << 3) };
+    }
+
+    /// Drive the LED low
+    fn clear(&mut self) {
+        const GPIO2_DR_CLEAR: *mut u32 = (GPIO2_BASE + 0x88) as *mut u32;
+        // Safety: modify global peripheral memory, but no one will ever notice
+        // since we don't return from the panic handler
+        unsafe { GPIO2_DR_CLEAR.write_volatile(1 << 3) };
+    }
+}
+
+fn delay(factor: u32) {
+    for _ in 0..(factor * 50_000_000) {
+        core::sync::atomic::spin_loop_hint();
+    }
+}
+
+fn triple(led: &mut LED, factor: u32) {
+    for _ in 0..3 {
+        led.set();
+        delay(factor);
+        led.clear();
+        delay(factor);
+    }
+}
+
+fn s(led: &mut LED) {
+    triple(led, 1);
+}
+
+fn o(led: &mut LED) {
+    triple(led, 3);
+}
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    let mut led = LED::new();
+    loop {
+        s(&mut led);
+        o(&mut led);
+        s(&mut led);
+        delay(6);
+    }
+}

--- a/teensy4-panic/src/lib.rs
+++ b/teensy4-panic/src/lib.rs
@@ -1,4 +1,25 @@
-//! Panic handler for Teensy 4 systems
+//! Panic handler for the Teensy 4
+//!
+//! When you link `teensy4-panic` into your program, any `panic!()` will cause
+//! your Teensy's LED to blink S.O.S. in Morse code. Supports both Teensy 4.0 and
+//! 4.1 boards.
+//!
+//! # Usage
+//!
+//! Depend on `teensy4-panic`:
+//!
+//! ```toml
+//! [dependencies]
+//! teensy4-panic = # ...
+//! ```
+//!
+//! Then, include the crate in your final program:
+//!
+//! ```rust
+//! use teensy4_panic as _;
+//! ```
+//!
+//! Finally, use `panic!()` to stop the program, and blink the LED.
 
 #![no_std]
 
@@ -11,7 +32,12 @@ impl LED {
     /// Construct the LED
     ///
     /// When `new` returns, the LED will be ready to set, clear, and toggle.
-    fn new() -> Self {
+    ///
+    /// # Safety
+    ///
+    /// There should only be one LED in the program. This will modify peripheral memory
+    /// to enable the LED.
+    unsafe fn new() -> Self {
         const IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_03: *mut u32 = 0x401F_8148 as *mut u32;
         const IOMUXC_SW_PAD_CTL_PAD_GPIO_B0_03: *mut u32 = 0x401F_8338 as *mut u32;
         const IOMUXC_GPR_GPR27: *mut u32 = 0x400A_C06C as *mut u32;
@@ -22,18 +48,13 @@ impl LED {
 
         const GPIO2_GDIR: *mut u32 = (GPIO2_BASE + 0x04) as *mut u32;
 
-        // Safety: this modifies IOMUXC memory that may be configured for another
-        // peripheral. But, this is a panic handler, and we're not returning from
-        // this state.
-        unsafe {
-            // Set the LED pad into Alt5
-            IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_03.write_volatile(5);
-            // Increase drive strength, clearing all other fields
-            IOMUXC_SW_PAD_CTL_PAD_GPIO_B0_03.write_volatile(drive_strength_enable(7));
-            // Disable fast mode so that GPIO2 registers drive the pad
-            IOMUXC_GPR_GPR27.write_volatile(IOMUXC_GPR_GPR27.read_volatile() & !(1 << 3));
-            GPIO2_GDIR.write_volatile(GPIO2_GDIR.read_volatile() | (1 << 3))
-        }
+        // Set the LED pad into Alt5
+        IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_03.write_volatile(5);
+        // Increase drive strength, clearing all other fields
+        IOMUXC_SW_PAD_CTL_PAD_GPIO_B0_03.write_volatile(drive_strength_enable(7));
+        // Disable fast mode so that GPIO2 registers drive the pad
+        IOMUXC_GPR_GPR27.write_volatile(IOMUXC_GPR_GPR27.read_volatile() & !(1 << 3));
+        GPIO2_GDIR.write_volatile(GPIO2_GDIR.read_volatile() | (1 << 3));
 
         LED()
     }
@@ -41,16 +62,12 @@ impl LED {
     /// Drive the LED high
     fn set(&mut self) {
         const GPIO2_DR_SET: *mut u32 = (GPIO2_BASE + 0x84) as *mut u32;
-        // Safety: modify global peripheral memory, but no one will ever notice
-        // since we don't return from the panic handler
         unsafe { GPIO2_DR_SET.write_volatile(1 << 3) };
     }
 
     /// Drive the LED low
     fn clear(&mut self) {
         const GPIO2_DR_CLEAR: *mut u32 = (GPIO2_BASE + 0x88) as *mut u32;
-        // Safety: modify global peripheral memory, but no one will ever notice
-        // since we don't return from the panic handler
         unsafe { GPIO2_DR_CLEAR.write_volatile(1 << 3) };
     }
 }
@@ -80,7 +97,7 @@ fn o(led: &mut LED) {
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    let mut led = LED::new();
+    let mut led = unsafe { LED::new() };
     loop {
         s(&mut led);
         o(&mut led);


### PR DESCRIPTION
The PR introduces `teensy4-panic`. Link with `teensy4-panic`, and any `panic!()` will cause the Teensy 4 to halt and blink S.O.S in Morse code. It's a fancier version of `panic-halt`, with an always-available output.

The panic handler will ignore any messages. Users who need these messages should consider a different panic handler, or write a handler that's specific to your system.