### PR TITLE
Document the runtime

### DIFF
--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -71,11 +71,8 @@ executes all instructions from ITCM.
 The second stage is written in Rust. It's defined in the BSP's `rt` runtime
 module. The second stage
 
-1. initialize MMU regions, instruction cache, and data cache\*
-2. overrides CCM low power behaviors for safer execution
-3. jumps to the `cortex-m-rt` reset handler to finish initialization
-
-_\* step subject to removal_
+1. overrides CCM low power behaviors for safer execution
+2. jumps to the `cortex-m-rt` reset handler to finish initialization
 
 The second stage must never read anything in a data section, since the memory
 is uninitialized.

--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -1,0 +1,89 @@
+`teensy4-bsp` runtime
+=====================
+
+This document describes how the `teensy4-bsp` runtime works. Before reading
+this document, it may help to first know about
+
+- the [`cortex-m-rt` package][cortex-m-rt], which is widely used for embedded
+  Rust development on Cortex-M systems
+- the default [Teensy 4 memory map](https://www.pjrc.com/store/teensy40.html),
+  which is what's used when developing applications with standard tools for the
+  Teensy 4.
+
+[cortex-m-rt]: https://github.com/rust-embedded/cortex-m-rt
+
+Memory Map
+----------
+
+`t4link.x` describes the BSP's memory map. The memory map is compatible with
+the `cortex-m-rt` requirements. Specifically, it includes symbols expected by
+the crate, such as
+
+- `__sbss` and `__ebss`
+- `__sdata`, `__edata`, and `__sidata`
+
+which lets the `cortex-m-rt` zero BSS and initialize data.
+
+The linker script also places the exception and interrupt tables. The exception
+table is defined in the `cortex-m-rt` crate. The interrupt table is defined in
+the `imxrt-ral` register access layer.
+
+The linker script satisfies the default Teensy 4 memory map. It places
+instructions in ITCM, all data in DTCM, and the stack at the top of DTCM.
+The linker script computes the ITCM and DTCM partition, ensuring that there's
+just enough space for instructions, with the rest of the space for data and
+stack.
+
+The boot data structures are placed at the start of flash.
+
+- The FlexSPI configuration block is defined in Rust. It's available in the
+  `teensy4-fcb` crate.
+- The IVT and remaining boot data is defined in the linker script
+
+The vector table, including the reset handler, is placed in flash. However,
+the vector table is copied into DTCM before program initialization. See the
+execution flow for more information.
+
+As of this writing, the RAM region is allocated for the Teensy 4's USB stack,
+written in C. This may change in future versions of the BSP. Sections placed in
+RAM are considered an implementation detail.
+
+Since the linker script is intended to fully replace the `cortex-m-rt` linker
+script, we include other directives necessary for a valid runtime. This support
+includes `PROVIDE`s, `EXTERN`s, and additional sections. By referring to this
+linker script in your build, you may use the `cortex-m-rt` runtime crate while
+still using the advanced memory layout available in i.MX RT microcontrollers.
+
+Execution
+---------
+
+On reset, execution begins in `start.s`, a precompiled assembly prelude that
+prepares the runtime's advanced features:
+
+1. initialize ITCM and DTCM regions
+2. copy all other instructions to ITCM
+3. copy the vector table to RAM, and initialize VTOR
+4. jump to the next stage
+
+The reset handler executes from flash (XIP). By step 4, after the copy, the MCU
+executes all instructions from ITCM.
+
+The second stage is written in Rust. It's defined in the BSP's `rt` runtime
+module. The second stage
+
+1. initialize MMU regions, instruction cache, and data cache\*
+2. overrides CCM low power behaviors for safer execution
+3. jumps to the `cortex-m-rt` reset handler to finish initialization
+
+_\* step subject to removal_
+
+The second stage must never read anything in a data section, since the memory
+is uninitialized.
+
+Execution then relies on the `cortex-m-rt` reset handler to finish system
+initialization, and invoke the program's entrypoint. This completes the BSP's
+runtime initialization.
+
+This execution lets us prepare TCM for the i.MX RT microcontrollers and meet
+the requirements of our memory layout, while still using the `cortex-m-rt` for
+complete system initialization.


### PR DESCRIPTION
The PR documents the BSP's runtime. It covers the memory map, and how we use `cortex-m-rt` despite having unique runtime requirements. It steps through how a BSP user's program is initialized and executed.

See #92.