### PR TITLE
Address new clippy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**BREAKING** Correct Rust symbol names, following the Rust API guidelines.
+These changes affect symbols in the BSP:
+
+- `LED => Led`
+- `usb::Error::IO => usb::Error::Io`
+
 ## [0.2.0] - 2021-01-09
 
 This release lets users combine the USB logging system with RTIC. The new

--- a/examples/bsp/src/bin/dma_uart.rs
+++ b/examples/bsp/src/bin/dma_uart.rs
@@ -113,7 +113,7 @@ fn main() -> ! {
         Ok(circular) => circular,
         Err(error) => {
             log::error!("Unable to create circular RX buffer: {:?}", error);
-            loop {}
+            panic!();
         }
     };
 

--- a/examples/bsp/src/bin/spi.rs
+++ b/examples/bsp/src/bin/spi.rs
@@ -67,7 +67,7 @@ fn main() -> ! {
                 err
             );
             loop {
-                core::sync::atomic::spin_loop_hint()
+                core::hint::spin_loop()
             }
         }
     };
@@ -76,8 +76,8 @@ fn main() -> ! {
     // dummy `OutputPin` that does nothing! If you'd rather use any
     // GPIO, replace this line to construct a GPIO from another pin.
     spi4.enable_chip_select_0(pins.p10);
-    struct DummyCS;
-    impl embedded_hal::digital::v2::OutputPin for DummyCS {
+    struct DummyChipSelect;
+    impl embedded_hal::digital::v2::OutputPin for DummyChipSelect {
         type Error = core::convert::Infallible;
         fn set_high(&mut self) -> Result<(), Self::Error> {
             Ok(())
@@ -86,7 +86,7 @@ fn main() -> ! {
             Ok(())
         }
     }
-    let mut cs4 = DummyCS;
+    let mut cs4 = DummyChipSelect;
     log::info!("Waiting 5 seconds before querying MPU9250...");
     systick.delay(4000);
 
@@ -95,7 +95,7 @@ fn main() -> ! {
         Err(err) => {
             log::warn!("Unable to initialize AK8963: {:?}", err);
             loop {
-                core::sync::atomic::spin_loop_hint()
+                core::hint::spin_loop()
             }
         }
     };

--- a/examples/bsp/src/bin/systick.rs
+++ b/examples/bsp/src/bin/systick.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
     let p = bsp::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
     let pins = bsp::t40::into_pins(p.iomuxc);
-    let mut led: bsp::LED = bsp::configure_led(pins.p13);
+    let mut led = bsp::configure_led(pins.p13);
 
     loop {
         systick.delay(LED_PERIOD_MS);

--- a/examples/bsp/src/bin/timer.rs
+++ b/examples/bsp/src/bin/timer.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
 
     let (timer0, timer1, _, mut timer3) = periphs.pit.clock(&mut cfg);
     let mut timer = pit::chain(timer0, timer1);
-    let mut led: bsp::LED = bsp::configure_led(pins.p13);
+    let mut led = bsp::configure_led(pins.p13);
     loop {
         let (_, period) = timer.time(|| {
             led.set_high().unwrap();

--- a/examples/bsp/src/bin/usb.rs
+++ b/examples/bsp/src/bin/usb.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(pins.p13);
+    let mut led = bsp::configure_led(pins.p13);
     let mut buffer = [0; 256];
     let mut counter = 0;
     loop {

--- a/examples/bsp/src/bin/usb_writer.rs
+++ b/examples/bsp/src/bin/usb_writer.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     p.ccm
         .pll1
         .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
-    let mut led: bsp::LED = bsp::configure_led(pins.p13);
+    let mut led = bsp::configure_led(pins.p13);
     let mut buffer = [0; 256];
     loop {
         let bytes_read = reader.read(&mut buffer).unwrap();

--- a/examples/rtic/src/bin/rtic_blink.rs
+++ b/examples/rtic/src/bin/rtic_blink.rs
@@ -21,7 +21,7 @@ const PERIOD: u32 = bsp::hal::ccm::PLL1::ARM_HZ;
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: bsp::LED,
+        led: bsp::Led,
     }
 
     #[init(schedule = [blink])]

--- a/examples/rtic/src/bin/rtic_dma_uart_log.rs
+++ b/examples/rtic/src/bin/rtic_dma_uart_log.rs
@@ -46,7 +46,7 @@ type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: bsp::LED,
+        led: bsp::Led,
         u_rx: UartRx,
         q_tx: Producer,
         q_rx: Consumer,

--- a/examples/rtic/src/bin/rtic_led.rs
+++ b/examples/rtic/src/bin/rtic_led.rs
@@ -31,7 +31,7 @@ const APP: () = {
     #[idle]
     fn idle(_: idle::Context) -> ! {
         loop {
-            core::sync::atomic::spin_loop_hint();
+            core::hint::spin_loop();
         }
     }
 };

--- a/examples/rtic/src/bin/rtic_uart_log.rs
+++ b/examples/rtic/src/bin/rtic_uart_log.rs
@@ -40,7 +40,7 @@ type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: bsp::LED,
+        led: bsp::Led,
         u_rx: UartRx,
         q_tx: Producer,
         q_rx: Consumer,

--- a/examples/rtic/src/bin/rtic_usb.rs
+++ b/examples/rtic/src/bin/rtic_usb.rs
@@ -24,7 +24,7 @@ const PERIOD: u32 = bsp::hal::ccm::PLL1::ARM_HZ;
 #[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: bsp::LED,
+        led: bsp::Led,
         poller: bsp::usb::Poller,
     }
 

--- a/examples/rtic/src/bin/rtic_usb_echo.rs
+++ b/examples/rtic/src/bin/rtic_usb_echo.rs
@@ -15,7 +15,7 @@ use teensy4_panic as _;
 #[rtic::app(device = teensy4_bsp, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: bsp::LED,
+        led: bsp::Led,
         reader: bsp::usb::Reader,
         writer: bsp::usb::Writer,
         poller: bsp::usb::Poller,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,13 +120,13 @@ pub use imxrt_hal as hal;
 /// The LED
 ///
 /// See [`configure_led`](configure_led()) to prepare the LED.
-pub type LED = hal::gpio::GPIO<common::P13, hal::gpio::Output>;
+pub type Led = hal::gpio::GPIO<common::P13, hal::gpio::Output>;
 
 /// Configure the board's LED
 ///
 /// Returns a GPIO that's physically tied to the LED. Use the returned handle
 /// to drive the LED.
-pub fn configure_led(pad: common::P13) -> LED {
+pub fn configure_led(pad: common::P13) -> Led {
     let mut led = hal::gpio::GPIO::new(pad);
     led.set_fast(true);
     led.output()

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -166,10 +166,10 @@ pub enum Error {
     ///
     /// Any USB CDC I/O method may return this error.
     NotConfigured,
-    /// Arbitrary IO error
+    /// Arbitrary I/O error
     ///
     /// Any USB CDC I/O method may return this error.
-    IO,
+    Io,
 }
 
 impl From<::log::SetLoggerError> for Error {
@@ -408,7 +408,7 @@ impl Writer {
         match res {
             bindings::SERIAL_NOT_CONFIGURED => Err(Error::NotConfigured),
             res if res >= 0 => Ok(res as usize),
-            _ => Err(Error::IO),
+            _ => Err(Error::Io),
         }
     }
 
@@ -480,7 +480,7 @@ impl Reader {
 
         let res = unsafe { bindings::serial_read(buffer) };
         if res < 0 {
-            Err(Error::IO)
+            Err(Error::Io)
         } else {
             Ok(res as usize)
         }

--- a/teensy4-panic/src/lib.rs
+++ b/teensy4-panic/src/lib.rs
@@ -24,11 +24,11 @@
 #![no_std]
 
 /// The LED
-struct LED();
+struct Led();
 
 const GPIO2_BASE: u32 = 0x401BC000;
 
-impl LED {
+impl Led {
     /// Construct the LED
     ///
     /// When `new` returns, the LED will be ready to set, clear, and toggle.
@@ -56,7 +56,7 @@ impl LED {
         IOMUXC_GPR_GPR27.write_volatile(IOMUXC_GPR_GPR27.read_volatile() & !(1 << 3));
         GPIO2_GDIR.write_volatile(GPIO2_GDIR.read_volatile() | (1 << 3));
 
-        LED()
+        Led()
     }
 
     /// Drive the LED high
@@ -74,11 +74,11 @@ impl LED {
 
 fn delay(factor: u32) {
     for _ in 0..(factor * 50_000_000) {
-        core::sync::atomic::spin_loop_hint();
+        core::hint::spin_loop();
     }
 }
 
-fn triple(led: &mut LED, factor: u32) {
+fn triple(led: &mut Led, factor: u32) {
     for _ in 0..3 {
         led.set();
         delay(factor);
@@ -87,17 +87,17 @@ fn triple(led: &mut LED, factor: u32) {
     }
 }
 
-fn s(led: &mut LED) {
+fn s(led: &mut Led) {
     triple(led, 1);
 }
 
-fn o(led: &mut LED) {
+fn o(led: &mut Led) {
     triple(led, 3);
 }
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    let mut led = unsafe { LED::new() };
+    let mut led = unsafe { Led::new() };
     loop {
         s(&mut led);
         o(&mut led);


### PR DESCRIPTION
Address the latest clippy warnings. This PR includes breaking changes in the BSP. See CHANGELOG for migration tips.