### PR TITLE
Migrate all RTIC examples to cortex-m-rtic 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ These changes affect symbols in the BSP:
 - `LED => Led`
 - `usb::Error::IO => usb::Error::Io`
 
+**BREAKING** Update cortex-m to 0.7.
+
 ## [0.2.2] - 2021-12-21
 
 Users can place the heap in DTCM using `dtcm_heap_start()`. This mimics the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ keywords = [
 ]
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.7"
 
 [target.thumbv7em-none-eabihf.dependencies.cortex-m-rt]
 version = "0.6.12"
@@ -240,7 +240,8 @@ required-features = ["rt", "rtic", "usb-logging"]
 # every host (notably fails on macOS). Only include it
 # when targeting the T4 MCU.
 [target.thumbv7em-none-eabihf.dev-dependencies]
-cortex-m-rtic = "0.5"
+cortex-m-rtic = "1.0"
+dwt-systick-monotonic = "1.0"
 
 [dev-dependencies]
 embedded-hal = "0.2"

--- a/examples/rtic_dma_uart_log.rs
+++ b/examples/rtic_dma_uart_log.rs
@@ -22,16 +22,9 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::OutputPin;
-use embedded_hal::serial::Read;
 use heapless::consts::U256;
-use rtic::cyccnt::U32Ext;
 use teensy4_bsp as bsp;
 use teensy4_panic as _;
-
-const PERIOD: u32 = bsp::hal::ccm::PLL1::ARM_HZ;
-const BAUD: u32 = 115_200;
-const TX_FIFO_SIZE: u8 = 4;
 
 // Type aliases for the Queue we want to use.
 type Ty = u8;
@@ -43,24 +36,49 @@ type Consumer = heapless::spsc::Consumer<'static, Ty, Cap>;
 // The UART receiver.
 type UartRx = bsp::hal::uart::Rx<bsp::hal::iomuxc::consts::U2>;
 
-#[rtic::app(device = teensy4_bsp, monotonic = rtic::cyccnt::CYCCNT, peripherals = true)]
-const APP: () = {
-    struct Resources {
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [LPUART8])]
+mod app {
+    use crate::{Consumer, Producer, Queue, UartRx};
+    use embedded_hal::digital::v2::OutputPin;
+    use embedded_hal::serial::Read;
+    use teensy4_bsp as bsp;
+
+    use dwt_systick_monotonic::{fugit::ExtU32, DwtSystick};
+
+    const BAUD: u32 = 115_200;
+    const TX_FIFO_SIZE: u8 = 4;
+    const MONO_HZ: u32 = bsp::hal::ccm::PLL1::ARM_HZ;
+    #[monotonic(binds = SysTick, default = true)]
+    type MyMono = DwtSystick<MONO_HZ>;
+
+    #[local]
+    struct Local {
         led: bsp::Led,
         u_rx: UartRx,
         q_tx: Producer,
         q_rx: Consumer,
+        blink_count: u32,
+    }
+
+    #[shared]
+    struct Shared {
         dma_interrupt_count: u32,
     }
 
-    #[init(schedule = [blink])]
-    fn init(mut cx: init::Context) -> init::LateResources {
-        cx.core.DWT.enable_cycle_counter();
-        cx.device.ccm.pll1.set_arm_clock(
-            bsp::hal::ccm::PLL1::ARM_HZ,
-            &mut cx.device.ccm.handle,
-            &mut cx.device.dcdc,
-        );
+    #[init(local = [
+        queue: Queue = heapless::spsc::Queue(heapless::i::Queue::new())
+    ])]
+    fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let mut dcb = cx.core.DCB;
+        let dwt = cx.core.DWT;
+        let systick = cx.core.SYST;
+
+        let mono = DwtSystick::new(&mut dcb, dwt, systick, MONO_HZ);
+
+        cx.device
+            .ccm
+            .pll1
+            .set_arm_clock(MONO_HZ, &mut cx.device.ccm.handle, &mut cx.device.dcdc);
 
         let pins = bsp::t40::into_pins(cx.device.iomuxc);
 
@@ -84,40 +102,43 @@ const APP: () = {
         imxrt_uart_log::dma::init(u_tx, channel, Default::default()).unwrap();
 
         // The queue used for buffering bytes.
-        static mut Q: Queue = heapless::spsc::Queue(heapless::i::Queue::new());
-        let (q_tx, q_rx) = unsafe { Q.split() };
+        let (q_tx, q_rx) = cx.local.queue.split();
 
         // LED setup.
         let mut led = bsp::configure_led(pins.p13);
         led.set_high().unwrap();
 
         // Schedule the first blink.
-        cx.schedule.blink(cx.start + PERIOD.cycles()).unwrap();
+        blink::spawn_after(1_u32.secs()).unwrap();
 
-        init::LateResources {
-            led,
-            u_rx,
-            q_tx,
-            q_rx,
-            dma_interrupt_count: 0,
-        }
+        (
+            Shared {
+                dma_interrupt_count: 0,
+            },
+            Local {
+                led,
+                u_rx,
+                q_tx,
+                q_rx,
+                blink_count: 0,
+            },
+            init::Monotonics(mono),
+        )
     }
 
-    #[task(resources = [led, q_rx, dma_interrupt_count], schedule = [blink])]
-    fn blink(cx: blink::Context) {
-        static mut TIMES: u32 = 0;
-        *TIMES += 1;
-        let plural = if *TIMES > 1 { "s" } else { "" };
-        log::info!("`blink` called {} time{}", *TIMES, plural);
-        log::info!(
-            "DMA7_DMA23 interrupted {} times",
-            cx.resources.dma_interrupt_count
-        );
+    #[task(local = [blink_count, led, q_rx], shared = [dma_interrupt_count])]
+    fn blink(mut cx: blink::Context) {
+        let plural = if *cx.local.blink_count > 1 { "s" } else { "" };
 
-        if cx.resources.q_rx.ready() {
+        log::info!("`blink` called {} time{}", cx.local.blink_count, plural);
+        cx.shared.dma_interrupt_count.lock(|count| {
+            log::info!("DMA7_DMA23 interrupted {} times", count);
+        });
+
+        if cx.local.q_rx.ready() {
             let mut buffer = [0u8; 256];
             for elem in buffer.iter_mut() {
-                *elem = match cx.resources.q_rx.dequeue() {
+                *elem = match cx.local.q_rx.dequeue() {
                     None => break,
                     Some(b) => b,
                 };
@@ -127,30 +148,26 @@ const APP: () = {
         }
 
         // Toggle the LED.
-        cx.resources.led.toggle();
+        cx.local.led.toggle();
 
         // Schedule the following blink.
-        cx.schedule.blink(cx.scheduled + PERIOD.cycles()).unwrap();
+        blink::spawn_after(1_u32.secs()).unwrap();
     }
 
-    #[task(binds = LPUART2, resources = [u_rx, q_tx])]
+    #[task(binds = LPUART2, local = [u_rx, q_tx])]
     fn lpuart2(cx: lpuart2::Context) {
         log::info!("LPUART2 interrupt task called!");
-        while let Ok(b) = cx.resources.u_rx.read() {
-            cx.resources.q_tx.enqueue(b).ok();
+        let u_rx = cx.local.u_rx;
+        let q_tx = cx.local.q_tx;
+
+        while let Ok(b) = u_rx.read() {
+            q_tx.enqueue(b).ok();
         }
     }
 
-    #[task(binds = DMA7_DMA23, resources = [dma_interrupt_count])]
-    fn dma7_dma23(cx: dma7_dma23::Context) {
-        *cx.resources.dma_interrupt_count += 1;
+    #[task(binds = DMA7_DMA23, shared = [dma_interrupt_count])]
+    fn dma7_dma23(mut cx: dma7_dma23::Context) {
+        cx.shared.dma_interrupt_count.lock(|count| *count += 1);
         imxrt_uart_log::dma::poll();
     }
-
-    // RTIC requires that unused interrupts are declared in an extern block when
-    // using software tasks; these free interrupts will be used to dispatch the
-    // software tasks.
-    extern "C" {
-        fn LPUART8();
-    }
-};
+}

--- a/examples/rtic_led.rs
+++ b/examples/rtic_led.rs
@@ -11,14 +11,20 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::OutputPin;
-use teensy4_bsp as bsp;
 use teensy4_panic as _;
 
 #[rtic::app(device = teensy4_bsp, peripherals = true)]
-const APP: () = {
+mod app {
+    use teensy4_bsp as bsp;
+
+    #[local]
+    struct Local {}
+
+    #[shared]
+    struct Shared {}
+
     #[init]
-    fn init(cx: init::Context) {
+    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
         // Cortex-M peripherals
         let _core: cortex_m::Peripherals = cx.core;
 
@@ -26,7 +32,9 @@ const APP: () = {
         let device: bsp::Peripherals = cx.device;
         let pins = bsp::t40::into_pins(device.iomuxc);
         let mut led = bsp::configure_led(pins.p13);
-        led.set_high().unwrap();
+        led.set();
+
+        (Shared {}, Local {}, init::Monotonics())
     }
     #[idle]
     fn idle(_: idle::Context) -> ! {
@@ -34,4 +42,4 @@ const APP: () = {
             core::hint::spin_loop();
         }
     }
-};
+}

--- a/examples/rtic_usb_echo.rs
+++ b/examples/rtic_usb_echo.rs
@@ -8,18 +8,25 @@
 #![no_std]
 #![no_main]
 
-use bsp::hal::ral::usb::USB1;
 use teensy4_bsp as bsp;
 use teensy4_panic as _;
 
-#[rtic::app(device = teensy4_bsp, peripherals = true)]
-const APP: () = {
-    struct Resources {
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [LPUART8])]
+mod app {
+    use super::copy;
+    use bsp::hal::ral::usb::USB1;
+    use teensy4_bsp as bsp;
+
+    #[local]
+    struct Local {
         led: bsp::Led,
         reader: bsp::usb::Reader,
         writer: bsp::usb::Writer,
         poller: bsp::usb::Poller,
     }
+
+    #[shared]
+    struct Shared {}
 
     /// Initialize the system
     ///
@@ -27,7 +34,7 @@ const APP: () = {
     /// - initialize the LED
     /// - initialize the USB reader and writer
     #[init]
-    fn init(mut cx: init::Context) -> init::LateResources {
+    fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
         cx.device.ccm.pll1.set_arm_clock(
             bsp::hal::ccm::PLL1::ARM_HZ,
             &mut cx.device.ccm.handle,
@@ -40,38 +47,35 @@ const APP: () = {
 
         let (poller, reader, writer) = bsp::usb::split(USB1::take().unwrap()).unwrap();
 
-        init::LateResources {
-            led,
-            poller,
-            reader,
-            writer,
-        }
+        (
+            Shared {},
+            Local {
+                led,
+                reader,
+                writer,
+                poller,
+            },
+            init::Monotonics(),
+        )
     }
 
     /// This task drives the USB stack. If it detects that the host has
     /// received USB data, it schedules a task to echo back that data
-    #[task(binds = USB_OTG1, spawn = [echo], resources = [poller])]
+    #[task(binds = USB_OTG1, local = [poller])]
     fn usb_otg1(cx: usb_otg1::Context) {
-        let status = cx.resources.poller.poll();
+        let status = cx.local.poller.poll();
         if status.cdc_rx_complete() {
-            cx.spawn.echo().unwrap();
+            echo::spawn().unwrap();
         }
     }
 
     /// Echo data back to the host
-    #[task(resources = [led, reader, writer])]
+    #[task(local = [led, reader, writer])]
     fn echo(cx: echo::Context) {
-        copy(cx.resources.reader, cx.resources.writer).unwrap();
-        cx.resources.led.toggle();
+        copy(cx.local.reader, cx.local.writer).unwrap();
+        cx.local.led.toggle();
     }
-
-    // RTIC requires that unused interrupts are declared in an extern block when
-    // using software tasks; these free interrupts will be used to dispatch the
-    // software tasks.
-    extern "C" {
-        fn LPUART8();
-    }
-};
+}
 
 /// Copy data from the reader to the writer
 fn copy(


### PR DESCRIPTION
The PR migrates all teensy4-rs RTIC examples to use cortex-m-rtic, version 0.6. See [here](https://rtic.rs/dev/book/en/migration/migration_v5.html) for the gist of the migration.

TODO

- [x] Remove alpha versions in dependencies once the next RTIC version is available

All examples work the same as they do on the main branch.