### PR TITLE
Expose teensy4-panic's SOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,5 @@ test:
 
 	@cargo +nightly test --manifest-path teensy4-pins/Cargo.toml --lib --tests --target $(HOST) --all-features
 	@cargo +nightly test --manifest-path teensy4-pins/Cargo.toml --doc --target $(HOST) --all-features
+
+	@cargo +nightly test --manifest-path teensy4-panic/Cargo.toml --doc --target $(HOST) --no-default-features

--- a/teensy4-panic/Cargo.toml
+++ b/teensy4-panic/Cargo.toml
@@ -23,3 +23,7 @@ keywords = [
 
 [package.metadata.docs.rs]
 default-target = "thumbv7em-none-eabihf"
+
+[features]
+default = ["panic-handler"]
+panic-handler = []

--- a/teensy4-panic/README.md
+++ b/teensy4-panic/README.md
@@ -12,7 +12,7 @@ Depend on `teensy4-panic`:
 
 ```toml
 [dependencies]
-teensy4-panic = # ...
+teensy4-panic = "0.2"
 ```
 
 Then, include the crate in your final program:
@@ -22,5 +22,27 @@ use teensy4_panic as _;
 ```
 
 Finally, use `panic!()` to stop the program, and blink the LED.
+
+## Custom panic handlers
+
+By default, `teensy4-panic` enables the `panic-handler` feature. If you want
+to use the S.O.S. routine in your own, custom panic handler, disable the default
+features, and call `sos()`:
+
+```toml
+[dependencies]
+teensy4-panic = "0.2"
+default-features = false
+```
+
+```rust
+use teensy4_panic::sos;
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    // ...
+    sos()
+}
+```
 
 License: MIT OR Apache-2.0

--- a/teensy4-panic/src/lib.rs
+++ b/teensy4-panic/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! teensy4-panic = # ...
+//! teensy4-panic = "0.2"
 //! ```
 //!
 //! Then, include the crate in your final program:
@@ -20,6 +20,32 @@
 //! ```
 //!
 //! Finally, use `panic!()` to stop the program, and blink the LED.
+//!
+//! # Custom panic handlers
+//!
+//! By default, `teensy4-panic` enables the `panic-handler` feature. If you want
+//! to use the S.O.S. routine in your own, custom panic handler, disable the default
+//! features, and call `sos()`:
+//!
+//! ```toml
+//! [dependencies]
+//! teensy4-panic = "0.2"
+//! default-features = false
+//! ```
+//!
+//! ```no_run
+//! # #![feature(lang_items)]
+//! # #![no_std]
+//! use teensy4_panic::sos;
+//!
+//! #[panic_handler]
+//! fn panic(_: &core::panic::PanicInfo) -> ! {
+//!     // ...
+//!     sos()
+//! }
+//! # fn main() {}
+//! # #[lang = "eh_personality"] extern fn rust_eh_personality() {}
+//! ```
 
 #![no_std]
 

--- a/teensy4-panic/src/lib.rs
+++ b/teensy4-panic/src/lib.rs
@@ -95,8 +95,18 @@ fn o(led: &mut Led) {
     triple(led, 3);
 }
 
+#[cfg(feature = "panic-handler")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
+    sos()
+}
+
+/// Blink S.O.S. on the LED, forever
+///
+/// This is the implementation of the `teensy4-panic` handler.
+/// See the crate-level docs for how you could use this in your
+/// own panic handler.
+pub fn sos() -> ! {
     let mut led = unsafe { Led::new() };
     loop {
         s(&mut led);


### PR DESCRIPTION
Allow a user to implement their own panic handler that can blink S.O.S. Disable the `teensy4-panic`'s default features, then implement your own custom panic handler.