### PR TITLE
Allocate the heap in OCRAM2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ These changes affect symbols in the BSP:
 - `LED => Led`
 - `usb::Error::IO => usb::Error::Io`
 
+Move the starting address for the heap into OCRAM2. Previously, the heap
+starting address was in DTCM, and it's expected to advance towards the stack.
+The relocation into OCRAM2 is consistent with the official Teensy 4 runtime, and
+allows you to have a larger heap (and stack, if heap allocation is used). The
+heap may occupy all address of OCRAM2 that are not allocated for DMA buffers.
+Heap-allocated state no longer benefits from the performance of DTCM.
+
 ## [0.2.0] - 2021-01-09
 
 This release lets users combine the USB logging system with RTIC. The new

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@ mod systick;
 #[cfg_attr(docsrs, doc(cfg(feature = "usb-logging")))]
 pub mod usb;
 
+#[cfg(all(target_arch = "arm", feature = "rt"))]
+pub use rt::{heap_len, heap_start};
 #[cfg(feature = "systick")]
 pub use systick::SysTick;
 

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -43,3 +43,22 @@ unsafe extern "C" fn t4_init() {
     }
     Reset(); // cortex-m-rt entrypoint
 }
+
+/// Returns the size of the heap, in bytes.
+///
+/// Use [`heap_start()`](crate::rt::heap_start) to access the start of the heap.
+pub fn heap_len() -> usize {
+    fn heap_end() -> *mut u32 {
+        extern "C" {
+            static mut __eheap: u32;
+        }
+        unsafe { &mut __eheap }
+    }
+
+    // Cannot use offset_from, since heap_end
+    // and heap_start are not derived from the
+    // same allocated object.
+    let end = heap_end() as usize;
+    let start = cortex_m_rt::heap_start() as usize;
+    end - start
+}

--- a/t4link.x
+++ b/t4link.x
@@ -160,6 +160,14 @@ SECTIONS
         . = ALIGN(16);
     } > RAM
 
+    .heap (NOLOAD) : ALIGN(4)
+    {
+        . = ALIGN(4);
+        __sheap = .;
+        . = ORIGIN(RAM) + LENGTH(RAM);
+        __eheap = .;
+    } > RAM
+
     /* ### .uninit */
     .uninit (NOLOAD) : ALIGN(4)
     {
@@ -167,10 +175,6 @@ SECTIONS
         *(.uninit .uninit.*);
         . = ALIGN(4);
     } > DTCM
-
-    /* Place the heap right after `.uninit` */
-    . = ALIGN(4);
-    __sheap = .;
 
     /* ## .got */
     /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
@@ -208,3 +212,6 @@ ERROR(cortex-m-rt): .bss is not 4-byte aligned");
 
 ASSERT(__stext % 4 == 0 && __etext % 4 == 0, "
 ERROR(cortex-m-rt): .text is not 4-byte aligned");
+
+ASSERT(__sheap % 4 == 0, "
+ERROR(cortex-m-rt): start of heap is not 4-byte aligned");


### PR DESCRIPTION
The heap starting address is in DTCM, right after `.uninit`. Observed using

```
cargo build --target=thumbv7em-none-eabihf --release --no-default-features --features=rt --example=led
rust-objdump -t target/thumbv7em-none-eabihf/release/examples/led | rg heap
```

The approach is OK, and consistent with how other systems might separate their stack and heap. However, it's inconsistent with the official Teensy 4 runtime, which allocates the heap in OCRAM2.

This PR moves the heap into OCRAM2. It's maximum possible size is 512KB (all of OCRAM2). In practice, there may be DMA buffers allocated in the memory region, so not all of the space is available. Use `heap_len()` to compute the actual amount for a given program.