### PR TITLE
Support optional logging in teensy4-panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,10 @@ name = "i2c"
 required-features = ["rt", "systick", "usb-logging"]
 
 [[example]]
+name = "panic_log"
+required-features = ["rt", "systick", "usb-logging", "teensy4-panic/log"]
+
+[[example]]
 name = "pwm"
 required-features = ["rt", "systick", "usb-logging"]
 
@@ -244,3 +248,4 @@ nb = "0.1"
 [dev-dependencies.teensy4-panic]
 version = "0.2"
 path = "teensy4-panic"
+features = ["log"]

--- a/examples/dma_memcpy.rs
+++ b/examples/dma_memcpy.rs
@@ -48,16 +48,14 @@ fn main() -> ! {
     let mut tx_buffer = match dma::Circular::new(&TX_MEMORY.0) {
         Ok(buffer) => buffer,
         Err(error) => {
-            log::error!("Unable to create the transfer buffer: {:?}", error);
-            panic!();
+            panic!("Unable to create the transfer buffer: {:?}", error);
         }
     };
 
     let mut rx_buffer = match dma::Circular::new(&RX_MEMORY.0) {
         Ok(buffer) => buffer,
         Err(error) => {
-            log::error!("Unable to create the receive buffer: {:?}", error);
-            panic!();
+            panic!("Unable to create the receive buffer: {:?}", error);
         }
     };
 
@@ -73,8 +71,7 @@ fn main() -> ! {
         rx_buffer.reserve(pattern.len());
 
         if let Err(error) = memcpy.transfer(tx_buffer, rx_buffer) {
-            log::error!("Unable to start memcpy: {:?}", error);
-            panic!();
+            panic!("Unable to start memcpy: {:?}", error);
         } else {
             log::info!("Transfer started...");
         }
@@ -92,8 +89,7 @@ fn main() -> ! {
                 buffers
             }
             None => {
-                log::error!("Memcpy didn't give us back the buffers!");
-                panic!();
+                panic!("Memcpy didn't give us back the buffers!");
             }
         };
 

--- a/examples/dma_spi.rs
+++ b/examples/dma_spi.rs
@@ -128,12 +128,11 @@ fn take_buffers() -> (TxBuffer, RxBuffer) {
         (tx_buffer, rx_buffer)
     });
     if tx_buffer.is_none() || rx_buffer.is_none() {
-        log::error!(
+        panic!(
             "Buffers are none! tx.is_none() == {}, rx.is_none() == {}",
             tx_buffer.is_none(),
             rx_buffer.is_none()
         );
-        panic!();
     }
 
     (tx_buffer.unwrap(), rx_buffer.unwrap())
@@ -197,12 +196,10 @@ fn main() -> ! {
             log::info!("Set clock speed to {}Hz", SPI_BAUD_RATE_HZ);
         }
         Err(err) => {
-            log::error!(
+            panic!(
                 "Unable to set clock speed to {}Hz: {:?}",
-                SPI_BAUD_RATE_HZ,
-                err
+                SPI_BAUD_RATE_HZ, err
             );
-            panic!();
         }
     };
 
@@ -242,14 +239,12 @@ fn main() -> ! {
             tx.set_transfer_len(1);
         };
         if tx_buffer_mut(prep_tx).is_none() {
-            log::error!("Cannot prepare transfer buffer");
-            panic!();
+            panic!("Cannot prepare transfer buffer");
         }
 
         let prep_rx = |rx: &mut dma::Linear<u16>| rx.set_transfer_len(1);
         if rx_buffer_mut(prep_rx).is_none() {
-            log::error!("Cannot prepare receive buffer");
-            panic!();
+            panic!("Cannot prepare receive buffer");
         }
         systick.delay(500);
 
@@ -267,8 +262,7 @@ fn main() -> ! {
                         log::warn!("Incorrect WHO_AM_I {:#X} received!", who_am_i);
                     }
                 } else {
-                    log::error!("RX buffer was inaccessible!");
-                    panic!();
+                    panic!("RX buffer was inaccessible!");
                 }
             }
         }
@@ -285,16 +279,14 @@ fn main() -> ! {
             tx.set_transfer_len(cmds.len());
         };
         if tx_buffer_mut(set_tx_buf).is_none() {
-            log::error!("Unable to modify transfer buffer!");
-            panic!();
+            panic!("Unable to modify transfer buffer!");
         }
 
         let set_rx_buf = |rx: &mut dma::Linear<u16>| {
             rx.set_transfer_len(cmds.len());
         };
         if rx_buffer_mut(set_rx_buf).is_none() {
-            log::error!("Unable to modify receive buffer!");
-            panic!();
+            panic!("Unable to modify receive buffer!");
         }
 
         systick.delay(500);

--- a/examples/dma_uart.rs
+++ b/examples/dma_uart.rs
@@ -112,8 +112,7 @@ fn main() -> ! {
     let rx_buffer = match bsp::hal::dma::Circular::new(&RX_MEM.0) {
         Ok(circular) => circular,
         Err(error) => {
-            log::error!("Unable to create circular RX buffer: {:?}", error);
-            panic!();
+            panic!("Unable to create circular RX buffer: {:?}", error);
         }
     };
 
@@ -128,8 +127,7 @@ fn main() -> ! {
 
         let mut rx_buffer = match free(|cs| RX_BUFFER.borrow(cs).borrow_mut().take()) {
             None => {
-                log::error!("No receive buffer!");
-                panic!();
+                panic!("No receive buffer!");
             }
             Some(rx_buffer) => rx_buffer,
         };
@@ -138,8 +136,7 @@ fn main() -> ! {
         // Schedule an initial receive
         let res = dma_uart.start_receive(rx_buffer);
         if let Err(err) = res {
-            log::error!("Error scheduling DMA receive: {:?}", err);
-            panic!();
+            panic!("Error scheduling DMA receive: {:?}", err);
         }
 
         loop {
@@ -159,8 +156,7 @@ fn main() -> ! {
                 log::info!("Received: {}", value);
                 let mut tx_buffer = match free(|cs| TX_BUFFER.borrow(cs).borrow_mut().take()) {
                     None => {
-                        log::error!("No transfer buffer!");
-                        panic!();
+                        panic!("No transfer buffer!");
                     }
                     Some(tx_buffer) => tx_buffer,
                 };
@@ -169,8 +165,7 @@ fn main() -> ! {
                 tx_buffer.set_transfer_len(1);
                 let res = dma_uart.start_transfer(tx_buffer);
                 if let Err(err) = res {
-                    log::warn!("Error scheduling DMA transfer: {:?}", err);
-                    panic!();
+                    panic!("Error scheduling DMA transfer: {:?}", err);
                 }
             } else if TX_READY.load(Ordering::Acquire) {
                 continue 'start;

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,4 +1,8 @@
-//! Demonstrates the panic handler
+//! Demonstrates a simple panic handler.
+//!
+//! This example does not write a panic message, nor does it set up
+//! logging. You should only observe a blinking LED. For a more advanced
+//! panic example, see panic_log.rs.
 
 #![no_std]
 #![no_main]

--- a/examples/panic_log.rs
+++ b/examples/panic_log.rs
@@ -1,0 +1,28 @@
+//! Demonstrates a panic handler that can log the panic message.
+//!
+//! Note: this example requires that the teensy4-panic crate's `log`
+//! feature is enabled. Otherwise, there will be no log message written
+//! over USB. The teensy4-panic crate's `log` feature is enabled for
+//! all BSP examples.
+
+#![no_std]
+#![no_main]
+
+mod usb_io;
+
+use teensy4_bsp as bsp;
+use teensy4_panic as _;
+
+const DELAY_MS: u32 = 5_000;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let mut p = bsp::Peripherals::take().unwrap();
+    let mut systick = bsp::SysTick::new(cortex_m::Peripherals::take().unwrap().SYST);
+    p.ccm
+        .pll1
+        .set_arm_clock(bsp::hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
+    usb_io::init().unwrap();
+    systick.delay(DELAY_MS);
+    panic!("This is a panic message written after {}ms", DELAY_MS);
+}

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -61,14 +61,10 @@ fn main() -> ! {
             log::info!("Set clock speed to {}Hz", SPI_BAUD_RATE_HZ);
         }
         Err(err) => {
-            log::error!(
+            panic!(
                 "Unable to set clock speed to {}Hz: {:?}",
-                SPI_BAUD_RATE_HZ,
-                err
+                SPI_BAUD_RATE_HZ, err
             );
-            loop {
-                core::hint::spin_loop()
-            }
         }
     };
 

--- a/teensy4-panic/Cargo.toml
+++ b/teensy4-panic/Cargo.toml
@@ -30,3 +30,7 @@ panic-handler = []
 
 [lib]
 test = false
+
+[dependencies.log]
+optional = true
+version = "0.4"

--- a/teensy4-panic/README.md
+++ b/teensy4-panic/README.md
@@ -1,6 +1,6 @@
 # teensy4-panic
 
-Panic handler for the Teensy 4
+Panic handler for the Teensy 4.
 
 When you link `teensy4-panic` into your program, any `panic!()` will cause
 your Teensy's LED to blink S.O.S. in Morse code. Supports both Teensy 4.0 and
@@ -21,12 +21,24 @@ Then, include the crate in your final program:
 use teensy4_panic as _;
 ```
 
-Finally, use `panic!()` to stop the program, and blink the LED.
+Finally, use `panic!()` to stop the program and blink the LED.
 
-## Custom panic handlers
+## Features
+
+The table below summarizes this crate's features. Each subsection details the feature.
+
+| Feature         |         Description                                | Default feature? |
+| --------------- | -------------------------------------------------- | ---------------- |
+| `panic-handler` | Define the Teensy 4's panic handler in this crate  |        ✓         |
+| `log`           | Log the panic message using `log::error!`          |                  |
+
+It does not make sense to _disable_ `panic-handler` and _enable_ `log`, since logging can
+only happen when `panic-handler` is enabled.
+
+### Custom panic handlers
 
 By default, `teensy4-panic` enables the `panic-handler` feature. If you want
-to use the S.O.S. routine in your own, custom panic handler, disable the default
+to use the S.O.S. routine in your own panic handler, disable the default
 features, and call `sos()`:
 
 ```toml
@@ -40,9 +52,28 @@ use teensy4_panic::sos;
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    // ...
+    // Your panic handler here...
     sos()
 }
 ```
+
+### Log the panic message
+
+If the `log` feature is enabled, the crate links with [the `log` crate](https://crates.io/crates/log).
+Before blinking, the panic handler logs the panic message and source location at the error priority,
+using `log::error!`. The logging target is `teensy4_panic`.
+
+The example below shows a `panic!` and an example of its corresponding log message:
+
+```rust
+const DELAY_MS: u32 = 5_000;
+panic!("This is a panic message written after {}ms", DELAY_MS);
+```
+```
+[ERROR teensy4_panic]: panicked at 'This is a panic message written after 5000ms', examples/panic_log.rs:22:5
+```
+
+The panic handler only emits the log message once. You're responsible for making sure that the
+log message can reach its destination while a `panic!` is active.
 
 License: MIT OR Apache-2.0

--- a/teensy4-panic/src/lib.rs
+++ b/teensy4-panic/src/lib.rs
@@ -1,4 +1,4 @@
-//! Panic handler for the Teensy 4
+//! Panic handler for the Teensy 4.
 //!
 //! When you link `teensy4-panic` into your program, any `panic!()` will cause
 //! your Teensy's LED to blink S.O.S. in Morse code. Supports both Teensy 4.0 and
@@ -19,12 +19,24 @@
 //! use teensy4_panic as _;
 //! ```
 //!
-//! Finally, use `panic!()` to stop the program, and blink the LED.
+//! Finally, use `panic!()` to stop the program and blink the LED.
 //!
-//! # Custom panic handlers
+//! # Features
+//!
+//! The table below summarizes this crate's features. Each subsection details the feature.
+//!
+//! | Feature         |         Description                                | Default feature? |
+//! | --------------- | -------------------------------------------------- | ---------------- |
+//! | `panic-handler` | Define the Teensy 4's panic handler in this crate  |        ✓         |
+//! | `log`           | Log the panic message using `log::error!`          |                  |
+//!
+//! It does not make sense to _disable_ `panic-handler` and _enable_ `log`, since logging can
+//! only happen when `panic-handler` is enabled.
+//!
+//! ## Custom panic handlers
 //!
 //! By default, `teensy4-panic` enables the `panic-handler` feature. If you want
-//! to use the S.O.S. routine in your own, custom panic handler, disable the default
+//! to use the S.O.S. routine in your own panic handler, disable the default
 //! features, and call `sos()`:
 //!
 //! ```toml
@@ -40,12 +52,31 @@
 //!
 //! #[panic_handler]
 //! fn panic(_: &core::panic::PanicInfo) -> ! {
-//!     // ...
+//!     // Your panic handler here...
 //!     sos()
 //! }
 //! # fn main() {}
 //! # #[lang = "eh_personality"] extern fn rust_eh_personality() {}
 //! ```
+//!
+//! ## Log the panic message
+//!
+//! If the `log` feature is enabled, the crate links with [the `log` crate](https://crates.io/crates/log).
+//! Before blinking, the panic handler logs the panic message and source location at the error priority,
+//! using `log::error!`. The logging target is `teensy4_panic`.
+//!
+//! The example below shows a `panic!` and an example of its corresponding log message:
+//!
+//! ```no_run
+//! const DELAY_MS: u32 = 5_000;
+//! panic!("This is a panic message written after {}ms", DELAY_MS);
+//! ```
+//! ```text
+//! [ERROR teensy4_panic]: panicked at 'This is a panic message written after 5000ms', examples/panic_log.rs:22:5
+//! ```
+//!
+//! The panic handler only emits the log message once. You're responsible for making sure that the
+//! log message can reach its destination while a `panic!` is active.
 
 #![no_std]
 
@@ -123,7 +154,16 @@ fn o(led: &mut Led) {
 
 #[cfg(feature = "panic-handler")]
 #[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    #[cfg(feature = "log")]
+    {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        // If logging results in another panic, we shouldn't try again.
+        static TRY_TO_LOG: AtomicBool = AtomicBool::new(true);
+        if TRY_TO_LOG.fetch_and(false, Ordering::Relaxed) {
+            log::error!("{}", _info);
+        }
+    }
     sos()
 }
 


### PR DESCRIPTION
The panic handler now has an optional log feature. If enabled, the default panic handler will log the panic message at the error level.

Try the new example to demonstrate the feature with the USB logger:

```
cargo run --example panic_log --target=thumbv7em-none-eabihf --release --all-features
```

An ISR-driven USB logger should be able to emits its log message. But, this might not be true if the panic happens within a critical section, or when the USB ISR is masked. There's a general caveat in the crate documentation, stating that users are responsible for making sure they can see the panic message.