### PR TITLE
Add support for DTCM heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ These changes affect symbols in the BSP:
 - `LED => Led`
 - `usb::Error::IO => usb::Error::Io`
 
+Users can place the heap in DTCM using `dtcm_heap_start()`. This mimics the
+behaviors of the 0.2.0 heap placement. See the 0.2.1 changelog note for more
+information.
+
+The table below summarizes the change in heap start APIs between 0.2.0 and
+0.2.2.
+
+| Heap location | Release 0.2.0  |    Release 0.2.2    |
+| ------------- | -------------- | ------------------- |
+|     DTCM      | `heap_start()` | `dtcm_heap_start()` |
+|    OCRAM2     |     None       |    `heap_start()`   |
+
+
 ## [0.2.1] - 2021-12-19
 
 Move the starting address for the heap into OCRAM2. Previously, the heap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod systick;
 pub mod usb;
 
 #[cfg(all(target_arch = "arm", feature = "rt"))]
-pub use rt::{heap_len, heap_start};
+pub use rt::{dtcm_heap_start, heap_len, heap_start};
 #[cfg(feature = "systick")]
 pub use systick::SysTick;
 

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -62,3 +62,20 @@ pub fn heap_len() -> usize {
     let start = cortex_m_rt::heap_start() as usize;
     end - start
 }
+
+/// Returns the starting location for a DTCM "heap."
+///
+/// The recommended heap is in OCRAM2, and available
+/// using [`heap_start()`](crate::rt::heap_start). But,
+/// you may choose to place the heap in DTCM. This function
+/// returns the starting address for that heap.
+///
+/// The DTCM heap is expected to grow up towards the stack,
+/// and has no statically-known maximum size. The pointer
+/// is guaranteed to be 4 byte aligned.
+pub fn dtcm_heap_start() -> *mut u32 {
+    extern "C" {
+        static mut __sheap_dtcm: u32;
+    }
+    unsafe { &mut __sheap_dtcm }
+}

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -47,6 +47,7 @@ unsafe extern "C" fn t4_init() {
 /// Returns the size of the heap, in bytes.
 ///
 /// Use [`heap_start()`](crate::rt::heap_start) to access the start of the heap.
+#[inline]
 pub fn heap_len() -> usize {
     fn heap_end() -> *mut u32 {
         extern "C" {
@@ -73,6 +74,7 @@ pub fn heap_len() -> usize {
 /// The DTCM heap is expected to grow up towards the stack,
 /// and has no statically-known maximum size. The pointer
 /// is guaranteed to be 4 byte aligned.
+#[inline]
 pub fn dtcm_heap_start() -> *mut u32 {
     extern "C" {
         static mut __sheap_dtcm: u32;

--- a/t4link.x
+++ b/t4link.x
@@ -154,6 +154,16 @@ SECTIONS
     . = ALIGN(4); /* Ensure __ebss is aligned if something unaligned is inserted after .bss */
     __ebss = .;
 
+    /* ### .uninit */
+    .uninit (NOLOAD) : ALIGN(4)
+    {
+        . = ALIGN(4);
+        *(.uninit .uninit.*);
+        . = ALIGN(4);
+    } > DTCM
+    . = ALIGN(4); /* Ensure alignment in case of INSERT AFTER */
+    __sheap_dtcm = .;
+
     .dma (NOLOAD) :
     {
         *(.dmabuffers); /* Compat with USB */
@@ -167,14 +177,6 @@ SECTIONS
         . = ORIGIN(RAM) + LENGTH(RAM);
         __eheap = .;
     } > RAM
-
-    /* ### .uninit */
-    .uninit (NOLOAD) : ALIGN(4)
-    {
-        . = ALIGN(4);
-        *(.uninit .uninit.*);
-        . = ALIGN(4);
-    } > DTCM
 
     /* ## .got */
     /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in


### PR DESCRIPTION
`dtcm_heap_start()` points to the recommended DTCM address for a heap. This mimics the behavior of the 0.2.0 BSP. If you use a heap, the table below shows how to migrate your heap initialization routines from 0.2.0 to 0.2.2.

| Heap location | Release 0.2.0  |    Release 0.2.2    |
| ------------- | -------------- | ------------------- |
|     DTCM      | `heap_start()` | `dtcm_heap_start()` |
|    OCRAM2     |     None       |    `heap_start()`   |

See #110 for more information.