### PR TITLE
Remove deprecated into_pins and pin modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+**BREAKING** Remove the `common`, `t40`, and `t41` modules. Users can access
+these modules through the re-export of `teensy4-pin`, simplified as `pins`.
+
 ## [0.3.0] - 2021-12-29
 
 **BREAKING** This release removes the `systick` module, and all SYSTICK APIs.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,20 +1,35 @@
 # `teensy4-bsp` Examples
 
-This directory contains examples that run on your Teensy 4.0 or Teensy 4.1.
-We separate examples based on their dependencies:
+This directory contains examples that run on your Teensy 4.0 or Teensy 4.1. It
+separates examples based on their dependencies:
 
 - The examples prefixed with `rtic_*` demonstrate the [RTIC] framework
 - Otherwise, the examples demonstrate how to directly use the BSP
 
-[RTIC]: https://rtic.rs/0.5/book/en/
+[RTIC]: https://rtic.rs
+
+To understand what each example should do, see the example's documentation at
+the top of the file.
 
 ## Build and run examples
 
 Make sure you have all of the build dependencies described in the [top-level
 README](../README.md#dependencies).
 
-First, build all of the examples for the MCU. Enable all BSP features to build
-all examples.
+If you have the `teensy_loader_cli` command-line loader installed, you may use
+`cargo run` to automatically build an example, convert the program, then call
+the loader to run it on hardware. The example below will build and flash the LED
+example:
+
+```
+cargo run --release --example led --features rt --target thumbv7em-none-eabihf
+```
+
+If you don't have the command-line loader installed, follow these steps to build
+all examples, then program an example of interest.
+
+Build all of the BSP examples for the MCU. When building all examples, enable
+all features:
 
 ```
 cargo build --release --examples --all-features --target thumbv7em-none-eabihf
@@ -28,14 +43,3 @@ rust-objcopy -O ihex target/thumbv7em-none-eabihf/release/examples/led led.hex
 ```
 
 Finally, load the HEX file onto your board. 
-
-To understand what each example should do, see the example's documentation at
-the top of the file.
-
-If you have the `teensy_loader_cli` command-line loader installed, you may use
-`cargo run` to automatically build an example, convert the program, then call
-the loader to run it on hardware:
-
-```
-cargo run --release --example led --features rt --target thumbv7em-none-eabihf
-```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,28 +85,6 @@ extern crate teensy4_fcb;
 
 pub use teensy4_pins as pins;
 
-/// Use [`teensy4_bsp::pins::common`](crate::pins::common).
-///
-/// This module will be removed in the next breaking release.
-#[deprecated(since = "0.3.0", note = "Use teensy4_bsp::pins::common")]
-pub mod common {
-    pub use crate::pins::common::*;
-}
-/// Use [`teensy4_bsp::pins::t40`](crate::pins::t40).
-///
-/// This module will be removed in the next breaking release.
-#[deprecated(since = "0.3.0", note = "Use teensy4_bsp::pins::t40")]
-pub mod t40 {
-    pub use crate::pins::t40::*;
-}
-/// Use [`teensy4_bsp::pins::t41`](crate::pins::t41).
-///
-/// This module will be removed in the next breaking release.
-#[deprecated(since = "0.3.0", note = "Use teensy4_bsp::pins::t41")]
-pub mod t41 {
-    pub use crate::pins::t41::*;
-}
-
 #[cfg(all(target_arch = "arm", feature = "rt"))]
 mod rt;
 #[cfg(feature = "usb-logging")]
@@ -128,13 +106,13 @@ pub use imxrt_hal as hal;
 /// The LED
 ///
 /// See [`configure_led`](configure_led()) to prepare the LED.
-pub type Led = hal::gpio::GPIO<common::P13, hal::gpio::Output>;
+pub type Led = hal::gpio::GPIO<pins::common::P13, hal::gpio::Output>;
 
 /// Configure the board's LED
 ///
 /// Returns a GPIO that's physically tied to the LED. Use the returned handle
 /// to drive the LED.
-pub fn configure_led(pad: common::P13) -> Led {
+pub fn configure_led(pad: pins::common::P13) -> Led {
     let mut led = hal::gpio::GPIO::new(pad);
     led.set_fast(true);
     led.output()

--- a/teensy4-pins/CHANGELOG.md
+++ b/teensy4-pins/CHANGELOG.md
@@ -6,6 +6,9 @@ Add Teensy 4.1 pins 48 though 54. This increases the size of the `ErasedPads`
 array and represents a **breaking** API change. Users who design to the
 `ErasedPads` type alias should not be affected by this breakage.
 
+**BREAKING** Remove `into_pins()`, which was deprecated in the previous
+release. Users should use `from_pads()`.
+
 ## [0.2.0] - 2021-12-29
 
 - Mark functions `#[inline]`.

--- a/teensy4-pins/src/t40.rs
+++ b/teensy4-pins/src/t40.rs
@@ -125,13 +125,6 @@ pub struct Pins {
     pub p39: P39,
 }
 
-/// Use [`from_pads`].
-#[deprecated(since = "0.2.0", note = "Use from_pads")]
-#[inline]
-pub const fn into_pins(iomuxc: crate::iomuxc::Pads) -> Pins {
-    from_pads(iomuxc)
-}
-
 /// Constrain the processor pads to the Teensy 4.0 pins
 #[inline]
 pub const fn from_pads(iomuxc: crate::iomuxc::Pads) -> Pins {

--- a/teensy4-pins/src/t41.rs
+++ b/teensy4-pins/src/t41.rs
@@ -200,13 +200,6 @@ pub struct Pins {
     pub p54: P54,
 }
 
-/// Use [`from_pads`].
-#[deprecated(since = "0.2.0", note = "Use from_pads")]
-#[inline]
-pub const fn into_pins(iomuxc: crate::iomuxc::Pads) -> Pins {
-    from_pads(iomuxc)
-}
-
 /// Constrain the processor pads to the Teensy 4.1 pins
 #[inline]
 pub const fn from_pads(iomuxc: crate::iomuxc::Pads) -> Pins {


### PR DESCRIPTION
The latest release marked some `teensy4-pins` and `teensy4-pins` APIs as deprecated. This PR removes those deprecated APIs.