### PR TITLE
Enable `Trng` clock gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fix the board clock configuration routines to enable the TRNG clock gate. This
+fixes a TRNG initialization defect that prevents random number generation. See
+issue 138 for details.
+
 ## [0.4.1] - 2023-02-09
 
 Add support for the Teensy MicroMod. See the updated `board` APIs and

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -200,6 +200,7 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::flexpwm::<4>(),
     clock_gate::adc::<1>(),
     clock_gate::adc::<2>(),
+    clock_gate::trng(),
 ];
 
 /// Prepare clock and power for the MCU.


### PR DESCRIPTION
Fixes: #138

If the `Trng` gets initialized before its clock gate is enabled, it seems to malfunction.

In the following workaround is the only way to fix it when using `teensy4-bsp`:
```rust
bsp::hal::ccm::clock_gate::trng().set(&mut ccm, bsp::hal::ccm::clock_gate::ON);
trng = bsp::hal::trng::Trng::new(
    trng.release_disabled(),
    Default::default(),
    Default::default(),
);
```

Meaning, to enable the clock gate and then re-initialize the `Trng` object.

This change fixes that problem by enabling the `Trng` clock gate in the bsp.