### PR TITLE
Expose flexspi2 register block

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -252,6 +252,8 @@ pub struct Resources<Pins> {
     pub flexpwm3: (hal::flexpwm::Pwm<3>, hal::flexpwm::Submodules<3>),
     /// FlexPWM4 components.
     pub flexpwm4: (hal::flexpwm::Pwm<4>, hal::flexpwm::Submodules<4>),
+    /// The FlexSPI2 register block.
+    pub flexspi2: ral::flexspi::FLEXSPI2,
     /// The register block for ADC1.
     ///
     /// ADC drivers constructed by `board` use a pre-configured clock and divisor. To change
@@ -580,6 +582,7 @@ fn prepare_resources<Pins>(
         flexpwm2: hal::flexpwm::new(instances.PWM2),
         flexpwm3: hal::flexpwm::new(instances.PWM3),
         flexpwm4: hal::flexpwm::new(instances.PWM4),
+        flexspi2: instances.FLEXSPI2,
         adc1,
         adc2,
         trng,


### PR DESCRIPTION
While a driver for it doesn't exist yet, it would still be already helpful (for driver development) to expose the raw FlexSPI registers, so we don't need to `unsafe`ly pry them out of `imxrt-ral`.

Especially for the Teensy MicroMod, where the FlexSPI [plays a central role](https://learn.sparkfun.com/tutorials/micromod-teensy-processor-hookup-guide/hardware-overview).

Exposing flexspi1 doesn't make sense (to my understanding), because it is connected to the flash memory that stores the executable code.