### PR TITLE
Make clock_power and its setup public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Expose `board::prepare_clocks_and_power` for users who want to configure their own
+resources with the BSP's clock policy.
+
 ## [0.4.3] 2023-07-18
 
 Update BSP documentation, noting that the `"usb-logging"` feature causes the BSP

--- a/src/board.rs
+++ b/src/board.rs
@@ -112,6 +112,9 @@
 //! gates to "off." `board` code that borrows or converts peripherals may assume that clock gates are
 //! set to "on."
 //!
+//! If you're not using the BSP to prepare board `Resources`, consider using [`prepare_clocks_and_power`]
+//! to realize the BSP's clock policy.
+//!
 //! # Naming conventions
 //!
 //! This module identifies peripherals by their hardware names. It does not use identifiers
@@ -516,7 +519,7 @@ fn prepare_resources<Pins>(
     mut instances: Instances,
     from_pads: impl FnOnce(hal::iomuxc::pads::Pads) -> Pins,
 ) -> Resources<Pins> {
-    super::clock_power::setup(
+    prepare_clocks_and_power(
         &mut instances.CCM,
         &mut instances.CCM_ANALOG,
         &mut instances.DCDC,

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -206,8 +206,11 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::trng(),
 ];
 
-/// Prepare clock and power for the MCU.
-pub(crate) fn setup(
+/// Prepare clocks and power for the MCU.
+///
+/// This implements the [`board`](crate::board#clock-policy)'s clock policy. This
+/// function is automatically called when acquiring board resources.
+pub fn prepare_clocks_and_power(
     ccm: &mut ral::ccm::CCM,
     ccm_analog: &mut ral::ccm_analog::CCM_ANALOG,
     dcdc: &mut ral::dcdc::DCDC,


### PR DESCRIPTION
I'm currently working on a project that requires very low-level access to peripherals. Because of this, I'm mostly working with the RAL and HAL, rather than the BSP. However, I don't want to have to configure all of the clock settings myself, and would like to let the BSP take care of this for me. Unfortunately, to do that, It's currently required to provide the raw peripheral instances over to the BSP, which causes an ownership transfer that I don't want to do.

Giving access to this function allows driver creators to let the teensy's clocks be set up easily, while still providing low-level access to everything else.