### PR TITLE
Add `log` feature to teensy-panic crate and bump version

### DIFF
--- a/teensy4-panic/Cargo.toml
+++ b/teensy4-panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teensy4-panic"
-version = "0.2.3"
+version = "0.2.4"
 authors.workspace = true
 edition.workspace = true
 readme = "README.md"
@@ -19,6 +19,7 @@ default-target = "thumbv7em-none-eabihf"
 [features]
 default = ["panic-handler"]
 panic-handler = []
+log = []
 
 [lib]
 test = false


### PR DESCRIPTION
The `teensy-panic` crate documentation says that a `log` feature may be enabled to have the panic handler output a log message when panicking. This feature was not actually present in the crate's `Cargo.toml` manifest, this PR adds it to the manifest and bumps the version from `0.2.3` to `0.2.4`.