### PR TITLE
Initialize Clock Gate for LPSPI3

### DIFF
--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -188,6 +188,7 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::snvs_lp(),
     clock_gate::lpi2c::<1>(),
     clock_gate::lpi2c::<3>(),
+    clock_gate::lpspi::<3>(),
     clock_gate::lpspi::<4>(),
     clock_gate::lpuart::<6>(),
     clock_gate::lpuart::<4>(),


### PR DESCRIPTION
I was attempting to use the SPI1 instance and found that initializing the LPSPI3 instance would cause the teensy to block.  Adding this line to the CLOCK_GATES fixed the issue and I was able to get the SPI1 instance working.