### PR TITLE
Expose LPUART1 resource from BSP

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -251,6 +251,8 @@ pub struct Resources<Pins> {
     pub lpuart3: ral::lpuart::LPUART3,
     /// The register block for [`Lpuart8`].
     pub lpuart8: ral::lpuart::LPUART8,
+    /// The register block for [`Lpuart1`].
+    pub lpuart1: ral::lpuart::LPUART1,
     /// FlexPWM1 components.
     pub flexpwm1: (hal::flexpwm::Pwm<1>, hal::flexpwm::Submodules<1>),
     /// FlexPWM2 components.
@@ -515,6 +517,14 @@ pub type Lpuart3 = hal::lpuart::Lpuart<hal::lpuart::Pins<pins::common::P17, pins
 /// Use [`lpuart`] to create this driver.
 pub type Lpuart8 = hal::lpuart::Lpuart<hal::lpuart::Pins<pins::common::P20, pins::common::P21>, 8>;
 
+/// LPUART1 peripheral.
+///
+/// - Pin 24 is TX.
+/// - Pin 25 is RX.
+///
+/// Use [`lpuart`] to create this driver.
+pub type Lpuart1 = hal::lpuart::Lpuart<hal::lpuart::Pins<pins::common::P24, pins::common::P25>, 1>;
+
 fn prepare_resources<Pins>(
     mut instances: Instances,
     from_pads: impl FnOnce(hal::iomuxc::pads::Pads) -> Pins,
@@ -589,6 +599,7 @@ fn prepare_resources<Pins>(
         lpuart2: instances.LPUART2,
         lpuart3: instances.LPUART3,
         lpuart8: instances.LPUART8,
+        lpuart1: instances.LPUART1,
         flexio1: instances.FLEXIO1,
         flexio2: instances.FLEXIO2,
         flexio3: instances.FLEXIO3,

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -195,6 +195,7 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::lpuart::<2>(),
     clock_gate::lpuart::<3>(),
     clock_gate::lpuart::<8>(),
+    clock_gate::lpuart::<1>(),
     clock_gate::flexpwm::<1>(),
     clock_gate::flexpwm::<2>(),
     clock_gate::flexpwm::<3>(),


### PR DESCRIPTION
Noted as missing in #151. I don't have hardware that makes this easy to test, but I ensured that modified `*_uart.rs` examples built as expected.

<details><summary>blocking_uart example with LPUART1</summary>
<p>

```rust
//! Demonstrates a loopback UART peripheral.
//!
//! It uses the alpha board, with the following pinout:
//!
//! - Pin 24 is TX.
//! - Pin 25 is RX.
//!
//! Baud rate is 115200bps.
//!
//! Every time you send the Teensy a character, it replies with
//! that same character, and it toggles the LED.

#![no_std]
#![no_main]

use teensy4_bsp as bsp;
use teensy4_panic as _;

use bsp::board;

use embedded_hal::serial::{Read, Write};

#[bsp::rt::entry]
fn main() -> ! {
    let board::Resources {
        pins,
        mut gpio2,
        lpuart1,
        ..
    } = board::t40(board::instances());
    let led = board::led(&mut gpio2, pins.p13);

    let mut lpuart1: board::Lpuart1 = board::lpuart(lpuart1, pins.p24, pins.p25, 115200);
    loop {
        led.toggle();
        let byte = nb::block!(lpuart1.read()).unwrap();
        nb::block!(lpuart1.write(byte)).unwrap();
    }
}
```

</p>
</details> 

<details><summary>rtic_uart example with LPUART1</summary>
<p>

```rust
//! A loopback device. Send characters, and you should see
//! the exact same characters sent back. The LED toggles for
//! every exchanged character.
//!
//! - Pin 24 is the Teensy's TX.
//! - Pin 25 is the Teensy's RX.
//!
//! Baud: 115200bps.

#![no_std]
#![no_main]

use teensy4_panic as _;

#[rtic::app(device = teensy4_bsp, peripherals = true)]
mod app {
    use bsp::board;
    use bsp::hal::lpuart;
    use teensy4_bsp as bsp;

    #[local]
    struct Local {
        led: board::Led,
        lpuart1: board::Lpuart1,
    }

    #[shared]
    struct Shared {}

    #[init]
    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
        let board::Resources {
            pins,
            lpuart1,
            mut gpio2,
            ..
        } = board::t40(cx.device);
        let led = board::led(&mut gpio2, pins.p13);
        led.set();

        let mut lpuart1: board::Lpuart1 = board::lpuart(lpuart1, pins.p24, pins.p25, 115200);
        lpuart1.disable(|lpuart1| {
            lpuart1.disable_fifo(lpuart::Direction::Tx);
            lpuart1.disable_fifo(lpuart::Direction::Rx);
            lpuart1.set_interrupts(lpuart::Interrupts::RECEIVE_FULL);
            lpuart1.set_parity(None);
        });
        (Shared {}, Local { led, lpuart1 }, init::Monotonics())
    }

    #[idle]
    fn idle(_: idle::Context) -> ! {
        loop {
            cortex_m::asm::wfi();
        }
    }

    #[task(binds = LPUART1, local = [led, lpuart1])]
    fn lpuart1_interrupt(cx: lpuart1_interrupt::Context) {
        use lpuart::Status;
        let lpuart1 = cx.local.lpuart1;
        let led = cx.local.led;

        let status = lpuart1.status();
        lpuart1.clear_status(Status::W1C);

        if status.contains(Status::RECEIVE_FULL) {
            loop {
                let data = lpuart1.read_data();
                if data.flags().contains(lpuart::ReadFlags::RXEMPT) {
                    break;
                }
                if lpuart1.status().contains(Status::TRANSMIT_EMPTY) {
                    lpuart1.write_byte(data.into());
                }
            }
            led.toggle();
        }
    }
}
```

</p>
</details> 