### PR TITLE
Make `imxrt-log` an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ version = "0.5.3"
 features = ["imxrt1060"]
 
 [dependencies.imxrt-log]
+optional = true
 version = "0.1"
 default-features = false
 features = ["usbd", "log", "defmt"]
@@ -74,7 +75,7 @@ members = [
 
 [features]
 rt = ["dep:imxrt-rt", "imxrt-ral/rt"]
-usb-logging = []
+usb-logging = ["dep:imxrt-log"]
 
 # This is a convenience for building examples.
 # When a user builds _all_ of the examples with
@@ -157,4 +158,4 @@ required-features = ["rt"]
 
 [[example]]
 name = "rtic_usb_log"
-required-features = ["rt"]
+required-features = ["rt", "usb-logging"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use imxrt_hal as hal;
+#[cfg(feature = "usb-logging")]
 pub use imxrt_log as logging;
 pub use imxrt_ral as ral;
 #[cfg(all(feature = "rt", target_arch = "arm", target_os = "none"))]


### PR DESCRIPTION
Hi all,

This is a small PR in an effort to reduce unused dependencies in my project tree.
For people (like me) that roll their own USB logging / serial communication, making `imxrt-log` optional reduces the size of the dependency tree a lot.

I don't have much experience with the inner workings of this project, so this is my best effort at guessing what it would take to make this work. Let me know what needs to change and I'll do my best to update this!

As a side note: I wasn't sure why the `rtic_usb_log` example didn't already have usb logging as a required feature, but it didn't build until I added it, if that's wrong or intentional please let me know.

Thanks for all the hard work! Really looking forward to developing on teensy with Rust.