### PR TITLE
Add BSP Support for FlexCAN(1/2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.5"
 features = ["imxrt1062"]
 
 [dependencies.imxrt-hal]
-version = "0.5.3"
+path = "../imxrt-hal"
 features = ["imxrt1060"]
 
 [dependencies.imxrt-rt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,10 @@ version = "0.5"
 features = ["imxrt1062"]
 
 [dependencies.imxrt-hal]
-path = "../imxrt-hal"
-features = ["imxrt1060"]
+git = "https://github.com/dstric-aqueduct/imxrt-hal"
+branch = "dev/can"
+#path = "../imxrt-hal"
+#features = ["imxrt1060"]
 
 [dependencies.imxrt-rt]
 version = "0.1.4"
@@ -119,6 +121,14 @@ required-features = ["rt"]
 [[example]]
 name = "blocking_uart"
 required-features = ["rt"]
+
+[[example]]
+name = "can"
+required-features = ["rt", "usb-logging"]
+
+[[example]]
+name = "rtic_can_log"
+required-features = ["rt", "rtic", "usb-logging"]
 
 [[example]]
 name = "rtic_configure_pin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ version = "0.4"
 version = "0.5"
 features = ["imxrt1062"]
 
-#[dependencies.imxrt-hal]
+[dependencies.imxrt-hal]
 #git = "https://github.com/dstric-aqueduct/imxrt-hal"
 #branch = "dev/can"
-#path = "../imxrt-hal"
-#features = ["imxrt1060"]
+path = "../imxrt-hal"
+features = ["imxrt1060"]
 
-[dependencies.imxrt-hal]
-version = "0.4.2"
-features = ["imxrt1062"]
+#[dependencies.imxrt-hal]
+#version = "0.4.2"
+#features = ["imxrt1062"]
 
-[patch.crates-io.imxrt-hal]
-git = "https://github.com/dstric-aqueduct/imxrt-hal"
-branch = "dev/can"
+#[patch.crates-io.imxrt-hal]
+#git = "https://github.com/dstric-aqueduct/imxrt-hal"
+#branch = "dev/can"
 
 [patch.crates-io.imxrt-iomuxc]
 git = "https://github.com/dstric-aqueduct/imxrt-iomuxc.git"
@@ -113,6 +113,7 @@ rtic = { version = "2", features = ["thumbv7-backend"] }
 rtic-monotonics = { version = "1", default-features = false, features = ["cortex-m-systick"] }
 usb-device = "0.2"
 usbd-serial = "0.1"
+heapless = "0.8"
 
 [[example]]
 name = "blocking_gpt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,24 @@ version = "0.4"
 version = "0.5"
 features = ["imxrt1062"]
 
-[dependencies.imxrt-hal]
-git = "https://github.com/dstric-aqueduct/imxrt-hal"
-branch = "dev/can"
+
+#[dependencies.imxrt-hal]
+#git = "https://github.com/dstric-aqueduct/imxrt-hal"
+#branch = "dev/can"
 #path = "../imxrt-hal"
 #features = ["imxrt1060"]
+
+[dependencies.imxrt-hal]
+version = "0.4.2"
+features = ["imxrt1062"]
+
+[patch.crates-io.imxrt-hal]
+git = "https://github.com/dstric-aqueduct/imxrt-hal"
+branch = "dev/can"
+
+[patch.crates-io.imxrt-iomuxc]
+git = "https://github.com/dstric-aqueduct/imxrt-iomuxc.git"
+tag = "v0.1.5-can"
 
 [dependencies.imxrt-rt]
 version = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ version = "0.4"
 version = "0.5"
 features = ["imxrt1062"]
 
-
 #[dependencies.imxrt-hal]
 #git = "https://github.com/dstric-aqueduct/imxrt-hal"
 #branch = "dev/can"
@@ -137,11 +136,11 @@ required-features = ["rt"]
 
 [[example]]
 name = "can"
-required-features = ["rt", "usb-logging"]
+required-features = ["rt"]
 
 [[example]]
 name = "rtic_can_log"
-required-features = ["rt", "rtic", "usb-logging"]
+required-features = ["rt"]
 
 [[example]]
 name = "rtic_configure_pin"

--- a/examples/can.rs
+++ b/examples/can.rs
@@ -3,7 +3,7 @@
 //! Pinout:
 //!
 //! - Teensy 4 Pin 22 (CAN1 TX) to TX pin of CAN Transceiver
-//! - Teensy 4 Pin 23 (CAN2 RX) to RX pin of CAN Transceiver
+//! - Teensy 4 Pin 23 (CAN1 RX) to RX pin of CAN Transceiver
 //!
 //! A Can transceiver (such as the Texas Instruments SN65HVD230) is required for this demo.
 //!

--- a/examples/can.rs
+++ b/examples/can.rs
@@ -41,11 +41,11 @@ fn main() -> ! {
 
     let (can1_builder, _) = peripherals.can.clock(
         &mut peripherals.ccm.handle,
-        bsp::hal::ccm::can::ClockSelect::Pll2,
+        bsp::hal::ccm::can::ClockSelect::OSC,
         bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
     );
 
-    let mut can1 = can1_builder.build();
+    let mut can1 = can1_builder.build(pins.p22, pins.p23);
     
     can1.set_baud_rate(1_000_000);
     can1.set_max_mailbox(16);

--- a/examples/can.rs
+++ b/examples/can.rs
@@ -1,0 +1,67 @@
+//! Demonstrates how to use a FlexCAN peripheral.
+//!
+//! Pinout:
+//!
+//! - Teensy 4 Pin 22 (CAN1 TX) to TX pin of CAN Transceiver 
+//! - Teensy 4 Pin 23 (CAN2 RX) to RX pin of CAN Transceiver 
+//!
+//! A Can transceiver (such as the Texas Instruments SN65HVD230) is required for this demo.
+//!
+
+#![no_std]
+#![no_main]
+
+mod systick;
+mod usb_io;
+
+use teensy4_panic as _;
+
+use cortex_m_rt::entry;
+use teensy4_bsp as bsp;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = bsp::Peripherals::take().unwrap();
+    let mut systick = systick::new(cortex_m::Peripherals::take().unwrap().SYST);
+
+    usb_io::init().unwrap();
+    let pins = bsp::pins::t40::from_pads(peripherals.iomuxc);
+
+    let mut led = bsp::configure_led(pins.p13);
+    led.set();
+
+    peripherals.ccm.pll1.set_arm_clock(
+        bsp::hal::ccm::PLL1::ARM_HZ,
+        &mut peripherals.ccm.handle,
+        &mut peripherals.dcdc,
+    );
+
+    systick.delay_ms(1000);
+    log::info!("Initializing CAN clocks...");
+
+    let (can1_builder, _) = peripherals.can.clock(
+        &mut peripherals.ccm.handle,
+        bsp::hal::ccm::can::ClockSelect::Pll2,
+        bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
+    );
+
+    let mut can1 = can1_builder.build();
+    
+    can1.set_baud_rate(1_000_000);
+    can1.set_max_mailbox(16);
+    can1.enable_fifo();
+    can1.set_fifo_interrupt(true);
+    can1.set_fifo_accept_all();
+    can1.print_registers();
+
+    let id = bsp::hal::can::Id::from(bsp::hal::can::StandardId::new(0x00).unwrap());
+    let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+    let frame = bsp::hal::can::Frame::new_data(id, data);
+
+    loop {
+        systick.delay_ms(1000);
+        led.toggle();
+        can1.read_mailboxes();
+        can1.transmit(&frame).ok();
+    }
+}

--- a/examples/rtic_can_log.rs
+++ b/examples/rtic_can_log.rs
@@ -16,141 +16,231 @@
 #![no_main]
 
 use teensy4_panic as _;
-mod usb_io;
 
 // Type aliases for the Queue we want to use.
-type Ty = u8;
-const CAP: usize = 256;
-type Queue = heapless::spsc::Queue<Ty, { CAP }>;
-type Consumer = heapless::spsc::Consumer<'static, Ty, { CAP }>;
+// type Ty = u8;
+// const CAP: usize = 256;
+// type Queue = heapless::spsc::Queue<Ty, { CAP }>;
+// type Consumer = heapless::spsc::Consumer<'static, Ty, { CAP }>;
 
-#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [LPUART8])]
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [KPP])]
 mod app {
-    use crate::{usb_io, Consumer, Queue};
-    use embedded_hal::digital::v2::OutputPin;
+    use bsp::board;
+//    use bsp::{
+//        board,
+//        hal::usbd::{
+//            gpt::{Instance::Gpt0, Mode},
+//            BusAdapter, EndpointMemory, EndpointState, Speed,
+//        },
+//    };
     use teensy4_bsp as bsp;
-    use bsp::hal::iomuxc::consts::U1;
 
-    use dwt_systick_monotonic::{fugit::ExtU32, DwtSystick};
+    use imxrt_log as logging;
 
-    #[monotonic(binds = SysTick, default = true)]
-    type MyMono = DwtSystick<{ bsp::hal::ccm::PLL1::ARM_HZ }>;
+
+    use rtic_monotonics::systick::*;
+
+
+
+    // FIXME: need these?
+
+    // use crate::{usb_io, Consumer, Queue};
+    // use crate::Consumer;
+    // use crate::Queue;
+    // use embedded_hal::digital::v2::OutputPin;
+    // use bsp::hal::iomuxc::consts::U1;
+
+    // use dwt_systick_monotonic::{fugit::ExtU32, DwtSystick};
+
+    // #[monotonic(binds = SysTick, default = true)]
+    // type MyMono = DwtSystick<{ bsp::hal::ccm::PLL1::ARM_HZ }>;
+
+
 
     #[local]
     struct Local {
-        led: bsp::Led,
-        q_rx: Consumer,
-        blink_count: u32,
+        /// For driving the logging endpoint.
+        poller: logging::Poller,
+        /// For periodically signaling activity.
+        led: board::Led,
+
+        // q_rx: Consumer,
+        // blink_count: u32,
     }
 
     #[shared]
     struct Shared {
-        can1: bsp::hal::can::CAN<U1>,
+        // can1: bsp::hal::common::can::CAN<U1>,
     }
 
-    #[init(local = [
-        queue: Queue = heapless::spsc::Queue::new(),
-    ])]
-    fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
-        let mut dcb = cx.core.DCB;
-        let dwt = cx.core.DWT;
-        let systick = cx.core.SYST;
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let board::Resources {
+            usb,
+            pins,
+            mut gpio2,
+            ..
+        } = board::t40(cx.device);
+        let led = board::led(&mut gpio2, pins.p13);
 
-        usb_io::init().unwrap();
+        // Set up the logging system.
+        //
+        // There's various ways to control log levels at build- and run-time.
+        // See the imxrt-log documentation for more information. This example
+        // doesn't demonstrate any of that.
+        let poller = logging::log::usbd(usb, logging::Interrupts::Enabled).unwrap();
 
-        let mono = DwtSystick::new(&mut dcb, dwt, systick, bsp::hal::ccm::PLL1::ARM_HZ);
+        // Set up a system timer for our software task.
+        {
+            Systick::start(
+                cx.core.SYST,
+                board::ARM_FREQUENCY,
+                rtic_monotonics::create_systick_token!(),
+            );
+        }
 
-        cx.device.ccm.pll1.set_arm_clock(
-            bsp::hal::ccm::PLL1::ARM_HZ,
-            &mut cx.device.ccm.handle,
-            &mut cx.device.dcdc,
-        );
-
-        let pins = bsp::pins::t40::from_pads(cx.device.iomuxc);
-
-        let (can1_builder, _) = peripherals.can.clock(
-            &mut peripherals.ccm.handle,
-            bsp::hal::ccm::can::ClockSelect::OSC,
-            bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
-        );
-    
-        let mut can1 = can1_builder.build(pins.p22, pins.p23);
+        // Schedule that software task to run.
+        make_logs::spawn().unwrap();
 
         // The queue used for buffering bytes.
-        let (_q_tx, q_rx) = cx.local.queue.split();
+        // let (_q_tx, q_rx) = cx.local.queue.split();
 
-        // LED setup.
-        let mut led = bsp::configure_led(pins.p13);
-        led.set_high().unwrap();
+//        let mut peripherals = bsp::hal::Peripherals::take().unwrap();
+//
+//        let (can1_builder, _) = peripherals.can.clock(
+//            &mut peripherals.ccm.handle,
+//            bsp::hal::ccm::can::ClockSelect::OSC,
+//            bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
+//        );
+//
+//        let mut can1 = can1_builder.build(pins.p22, pins.p23);
+//
+//        can1_init::spawn_after(1_u32.secs()).unwrap();
 
         // Schedule the first blink.
-        blink::spawn_after(1_u32.secs()).unwrap();
+        // blink::spawn_after(1_u32.secs()).unwrap();
 
-        can1_init::spawn_after(1_u32.secs()).unwrap();
+        // If the LED turns on, we've made it past init.
+        led.set();
 
         (
-            Shared { can1 },
-            Local {
-                led,
-                q_rx,
-                blink_count: 0,
+            Shared {
+                // can1,
             },
-            init::Monotonics(mono),
+            Local {
+                poller,
+                led,
+                // q_rx,
+                // blink_count: 0,
+            },
+            // init::Monotonics(mono),
         )
     }
 
-    #[task(local = [led, q_rx, blink_count])]
-    fn blink(cx: blink::Context) {
-        if cx.local.q_rx.ready() {
-            let mut buffer = [0u8; 256];
-            for elem in buffer.iter_mut() {
-                *elem = match cx.local.q_rx.dequeue() {
-                    None => break,
-                    Some(b) => b,
-                };
+    // #[init(local = [
+    // ])]
+    // fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
+        // let mut dcb = cx.core.DCB;
+        // let dwt = cx.core.DWT;
+        // let systick = cx.core.SYST;
+// 
+    // }
+
+    /// This task periodically logs data.
+    ///
+    /// You won't see all the log levels until you configure your build. See the
+    /// top-level docs for more information.
+    #[task(local = [led])]
+    async fn make_logs(cx: make_logs::Context) {
+        let make_logs::LocalResources { led, .. } = cx.local;
+
+        let mut counter = 0u32;
+        loop {
+            led.toggle();
+            Systick::delay(250.millis()).await;
+
+            log::trace!("TRACE: {}", counter);
+
+            if counter % 3 == 0 {
+                log::debug!("DEBUG: {}", counter);
             }
-            let s = core::str::from_utf8(&buffer).unwrap();
-            log::info!("read: {}", s);
+
+            if counter % 5 == 0 {
+                log::info!("INFO: {}", counter);
+            }
+
+            if counter % 7 == 0 {
+                log::warn!("WARN: {}", counter);
+            }
+
+            if counter % 31 == 0 {
+                log::error!("ERROR: {}", counter);
+            }
+
+            counter = counter.wrapping_add(1);
         }
-
-        // Toggle the LED.
-        cx.local.led.toggle();
-
-        // Schedule the following blink.
-        blink::spawn_after(100_u32.millis()).unwrap();
     }
 
-    #[task(shared = [can1])]
-    fn can1_init(mut cx: can1_init::Context) {
-        cx.shared.can1.lock(|can1| {
-            can1.set_baud_rate(1_000_000);
-            can1.set_max_mailbox(16);
-            can1.enable_fifo();
-            can1.set_fifo_interrupt(true);
-            can1.set_fifo_accept_all();
-            can1.print_registers();
-        });
-        can1::spawn_after(100_u32.millis()).unwrap();
+
+    /// This task runs when the USB1 interrupt activates.
+    /// Simply poll the logger to control the logging process.
+    #[task(binds = USB_OTG1, local = [poller])]
+    fn usb_interrupt(cx: usb_interrupt::Context) {
+        cx.local.poller.poll();
     }
 
-    #[task(shared = [can1])]
-    fn can1(mut cx: can1::Context) {
-        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-        let id = bsp::hal::can::Id::from(bsp::hal::can::StandardId::new(0x00).unwrap());
-        let frame = bsp::hal::can::Frame::new_data(id, data);
-        cx.shared.can1.lock(|can1| {
-            can1.transmit(&frame).ok();
-        });
-        can1::spawn_after(100_u32.millis()).unwrap();
-    }
+//     #[task(local = [led, q_rx, blink_count])]
+//     async fn blink(cx: blink::Context) {
+//         if cx.local.q_rx.ready() {
+//             let mut buffer = [0u8; 256];
+//             for elem in buffer.iter_mut() {
+//                 *elem = match cx.local.q_rx.dequeue() {
+//                     None => break,
+//                     Some(b) => b,
+//                 };
+//             }
+//             let s = core::str::from_utf8(&buffer).unwrap();
+//             log::info!("read: {}", s);
+//         }
+//
+//         // Toggle the LED.
+//         cx.local.led.toggle();
+//
+//         // Schedule the following blink.
+//         blink::spawn_after(100_u32.millis()).unwrap();
+//     }
 
-    #[task(binds = CAN1, shared = [can1],)]
-    fn can1_int(mut cx: can1_int::Context) {
-        cx.shared.can1.lock(|can1| {
-            match can1.handle_interrupt() {
-                Some(f) => log::info!("Rx: {:?}", &f),
-                None => { },
-            };
-        });
-    }
+//    #[task(shared = [can1])]
+//    async fn can1_init(mut cx: can1_init::Context) {
+//        cx.shared.can1.lock(|can1| {
+//            can1.set_baud_rate(1_000_000);
+//            can1.set_max_mailbox(16);
+//            can1.enable_fifo();
+//            can1.set_fifo_interrupt(true);
+//            can1.set_fifo_accept_all();
+//            can1.print_registers();
+//        });
+//        can1::spawn_after(100_u32.millis()).unwrap();
+//    }
+//
+//    #[task(shared = [can1])]
+//    async fn can1(mut cx: can1::Context) {
+//        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+//        let id = bsp::hal::can::Id::from(bsp::hal::can::StandardId::new(0x00).unwrap());
+//        let frame = bsp::hal::can::Frame::new_data(id, data);
+//        cx.shared.can1.lock(|can1| {
+//            can1.transmit(&frame).ok();
+//        });
+//        can1::spawn_after(100_u32.millis()).unwrap();
+//    }
+//
+//    #[task(binds = CAN1, shared = [can1],)]
+//    fn can1_int(mut cx: can1_int::Context) {
+//        cx.shared.can1.lock(|can1| {
+//            match can1.handle_interrupt() {
+//                Some(f) => log::info!("Rx: {:?}", &f),
+//                None => { },
+//            };
+//        });
+//    }
 }

--- a/examples/rtic_can_log.rs
+++ b/examples/rtic_can_log.rs
@@ -26,21 +26,11 @@ use teensy4_panic as _;
 #[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [KPP])]
 mod app {
     use bsp::board;
-//    use bsp::{
-//        board,
-//        hal::usbd::{
-//            gpt::{Instance::Gpt0, Mode},
-//            BusAdapter, EndpointMemory, EndpointState, Speed,
-//        },
-//    };
     use teensy4_bsp as bsp;
 
     use imxrt_log as logging;
 
-
     use rtic_monotonics::systick::*;
-
-
 
     // FIXME: need these?
 
@@ -55,32 +45,29 @@ mod app {
     // #[monotonic(binds = SysTick, default = true)]
     // type MyMono = DwtSystick<{ bsp::hal::ccm::PLL1::ARM_HZ }>;
 
-
-
     #[local]
     struct Local {
         /// For driving the logging endpoint.
         poller: logging::Poller,
         /// For periodically signaling activity.
         led: board::Led,
-
         // q_rx: Consumer,
         // blink_count: u32,
+        can: board::Flexcan1,
     }
 
     #[shared]
-    struct Shared {
-        // can1: bsp::hal::common::can::CAN<U1>,
-    }
+    struct Shared {}
 
     #[init]
     fn init(cx: init::Context) -> (Shared, Local) {
         let board::Resources {
             usb,
             pins,
+            flexcan1,
             mut gpio2,
             ..
-        } = board::t40(cx.device);
+        } = board::t41(cx.device);
         let led = board::led(&mut gpio2, pins.p13);
 
         // Set up the logging system.
@@ -90,6 +77,12 @@ mod app {
         // doesn't demonstrate any of that.
         let poller = logging::log::usbd(usb, logging::Interrupts::Enabled).unwrap();
 
+        let mut can = board::flexcan(flexcan1, pins.p22, pins.p23);
+        can.set_baud_rate(125_000);
+        can.set_max_mailbox(16);
+        can.enable_fifo();
+        can.set_fifo_interrupt(true);
+        can.set_fifo_accept_all();
         // Set up a system timer for our software task.
         {
             Systick::start(
@@ -105,46 +98,48 @@ mod app {
         // The queue used for buffering bytes.
         // let (_q_tx, q_rx) = cx.local.queue.split();
 
-//        let mut peripherals = bsp::hal::Peripherals::take().unwrap();
-//
-//        let (can1_builder, _) = peripherals.can.clock(
-//            &mut peripherals.ccm.handle,
-//            bsp::hal::ccm::can::ClockSelect::OSC,
-//            bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
-//        );
-//
-//        let mut can1 = can1_builder.build(pins.p22, pins.p23);
-//
-//        can1_init::spawn_after(1_u32.secs()).unwrap();
+        //        let mut peripherals = bsp::hal::Peripherals::take().unwrap();
+        //
+        //        let (can1_builder, _) = peripherals.can.clock(
+        //            &mut peripherals.ccm.handle,
+        //            bsp::hal::ccm::can::ClockSelect::OSC,
+        //            bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
+        //        );
+        //
+        //        let mut can1 = can1_builder.build(pins.p22, pins.p23);
+        //
+        //        can1_init::spawn_after(1_u32.secs()).unwrap();
 
         // Schedule the first blink.
         // blink::spawn_after(1_u32.secs()).unwrap();
 
+        run_can::spawn().unwrap();
         // If the LED turns on, we've made it past init.
         led.set();
 
-        (
-            Shared {
-                // can1,
-            },
-            Local {
-                poller,
-                led,
-                // q_rx,
-                // blink_count: 0,
-            },
-            // init::Monotonics(mono),
-        )
+        (Shared {}, Local { poller, led, can })
     }
 
-    // #[init(local = [
-    // ])]
-    // fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
-        // let mut dcb = cx.core.DCB;
-        // let dwt = cx.core.DWT;
-        // let systick = cx.core.SYST;
-// 
-    // }
+    #[task(local = [can])]
+    async fn run_can(cx: run_can::Context) {
+        let run_can::LocalResources { can, .. } = cx.local;
+        // create a `Frame` with `StandardID` 0x00
+        // and `Data` [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+        let id = imxrt_hal::can::Id::from(imxrt_hal::can::StandardId::new(0x00).unwrap());
+        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let frame = imxrt_hal::can::Frame::new_data(id, data);
+
+        loop {
+            // read all available mailboxes for any available frames
+            can.read_mailboxes();
+
+            // transmit the frame
+            can.transmit(&frame);
+            log::info!("Transmit");
+
+            Systick::delay(1000.millis()).await;
+        }
+    }
 
     /// This task periodically logs data.
     ///
@@ -181,7 +176,6 @@ mod app {
         }
     }
 
-
     /// This task runs when the USB1 interrupt activates.
     /// Simply poll the logger to control the logging process.
     #[task(binds = USB_OTG1, local = [poller])]
@@ -189,58 +183,58 @@ mod app {
         cx.local.poller.poll();
     }
 
-//     #[task(local = [led, q_rx, blink_count])]
-//     async fn blink(cx: blink::Context) {
-//         if cx.local.q_rx.ready() {
-//             let mut buffer = [0u8; 256];
-//             for elem in buffer.iter_mut() {
-//                 *elem = match cx.local.q_rx.dequeue() {
-//                     None => break,
-//                     Some(b) => b,
-//                 };
-//             }
-//             let s = core::str::from_utf8(&buffer).unwrap();
-//             log::info!("read: {}", s);
-//         }
-//
-//         // Toggle the LED.
-//         cx.local.led.toggle();
-//
-//         // Schedule the following blink.
-//         blink::spawn_after(100_u32.millis()).unwrap();
-//     }
+    //     #[task(local = [led, q_rx, blink_count])]
+    //     async fn blink(cx: blink::Context) {
+    //         if cx.local.q_rx.ready() {
+    //             let mut buffer = [0u8; 256];
+    //             for elem in buffer.iter_mut() {
+    //                 *elem = match cx.local.q_rx.dequeue() {
+    //                     None => break,
+    //                     Some(b) => b,
+    //                 };
+    //             }
+    //             let s = core::str::from_utf8(&buffer).unwrap();
+    //             log::info!("read: {}", s);
+    //         }
+    //
+    //         // Toggle the LED.
+    //         cx.local.led.toggle();
+    //
+    //         // Schedule the following blink.
+    //         blink::spawn_after(100_u32.millis()).unwrap();
+    //     }
 
-//    #[task(shared = [can1])]
-//    async fn can1_init(mut cx: can1_init::Context) {
-//        cx.shared.can1.lock(|can1| {
-//            can1.set_baud_rate(1_000_000);
-//            can1.set_max_mailbox(16);
-//            can1.enable_fifo();
-//            can1.set_fifo_interrupt(true);
-//            can1.set_fifo_accept_all();
-//            can1.print_registers();
-//        });
-//        can1::spawn_after(100_u32.millis()).unwrap();
-//    }
-//
-//    #[task(shared = [can1])]
-//    async fn can1(mut cx: can1::Context) {
-//        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-//        let id = bsp::hal::can::Id::from(bsp::hal::can::StandardId::new(0x00).unwrap());
-//        let frame = bsp::hal::can::Frame::new_data(id, data);
-//        cx.shared.can1.lock(|can1| {
-//            can1.transmit(&frame).ok();
-//        });
-//        can1::spawn_after(100_u32.millis()).unwrap();
-//    }
-//
-//    #[task(binds = CAN1, shared = [can1],)]
-//    fn can1_int(mut cx: can1_int::Context) {
-//        cx.shared.can1.lock(|can1| {
-//            match can1.handle_interrupt() {
-//                Some(f) => log::info!("Rx: {:?}", &f),
-//                None => { },
-//            };
-//        });
-//    }
+    //    #[task(shared = [can1])]
+    //    async fn can1_init(mut cx: can1_init::Context) {
+    //        cx.shared.can1.lock(|can1| {
+    //            can1.set_baud_rate(1_000_000);
+    //            can1.set_max_mailbox(16);
+    //            can1.enable_fifo();
+    //            can1.set_fifo_interrupt(true);
+    //            can1.set_fifo_accept_all();
+    //            can1.print_registers();
+    //        });
+    //        can1::spawn_after(100_u32.millis()).unwrap();
+    //    }
+    //
+    //    #[task(shared = [can1])]
+    //    async fn can1(mut cx: can1::Context) {
+    //        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+    //        let id = bsp::hal::can::Id::from(bsp::hal::can::StandardId::new(0x00).unwrap());
+    //        let frame = bsp::hal::can::Frame::new_data(id, data);
+    //        cx.shared.can1.lock(|can1| {
+    //            can1.transmit(&frame).ok();
+    //        });
+    //        can1::spawn_after(100_u32.millis()).unwrap();
+    //    }
+    //
+    //    #[task(binds = CAN1, shared = [can1],)]
+    //    fn can1_int(mut cx: can1_int::Context) {
+    //        cx.shared.can1.lock(|can1| {
+    //            match can1.handle_interrupt() {
+    //                Some(f) => log::info!("Rx: {:?}", &f),
+    //                None => { },
+    //            };
+    //        });
+    //    }
 }

--- a/examples/rtic_can_log.rs
+++ b/examples/rtic_can_log.rs
@@ -30,7 +30,7 @@ mod app {
 
     use imxrt_log as logging;
 
-    use rtic_monotonics::systick::*;
+    use rtic_monotonics::systick::{self, *};
 
     // FIXME: need these?
 
@@ -53,11 +53,12 @@ mod app {
         led: board::Led,
         // q_rx: Consumer,
         // blink_count: u32,
-        can: board::Flexcan1,
     }
 
     #[shared]
-    struct Shared {}
+    struct Shared {
+        can: board::Flexcan1,
+    }
 
     #[init]
     fn init(cx: init::Context) -> (Shared, Local) {
@@ -80,9 +81,9 @@ mod app {
         let mut can = board::flexcan(flexcan1, pins.p22, pins.p23);
         can.set_baud_rate(125_000);
         can.set_max_mailbox(16);
-        can.enable_fifo();
-        can.set_fifo_interrupt(true);
-        can.set_fifo_accept_all();
+        can.disable_fifo();
+        // can.set_fifo_interrupt(true);
+        // can.set_fifo_accept_all();
         // Set up a system timer for our software task.
         {
             Systick::start(
@@ -93,7 +94,7 @@ mod app {
         }
 
         // Schedule that software task to run.
-        make_logs::spawn().unwrap();
+        // make_logs::spawn().unwrap();
 
         // The queue used for buffering bytes.
         // let (_q_tx, q_rx) = cx.local.queue.split();
@@ -111,32 +112,41 @@ mod app {
         //        can1_init::spawn_after(1_u32.secs()).unwrap();
 
         // Schedule the first blink.
-        // blink::spawn_after(1_u32.secs()).unwrap();
+        blink::spawn().unwrap();
 
-        run_can::spawn().unwrap();
+        run_can_rx::spawn().unwrap();
+        run_can_tx::spawn().unwrap();
         // If the LED turns on, we've made it past init.
         led.set();
 
-        (Shared {}, Local { poller, led, can })
+        (Shared { can }, Local { poller, led })
     }
 
-    #[task(local = [can])]
-    async fn run_can(cx: run_can::Context) {
-        let run_can::LocalResources { can, .. } = cx.local;
+    #[task(shared = [can])]
+    async fn run_can_rx(cx: run_can_rx::Context) {
+        let run_can_rx::SharedResources { mut can, .. } = cx.shared;
+        loop {
+            // read all available mailboxes for any available frames
+            if let Some(data) = can.lock(|can| can.read_mailboxes()) {
+                log::info!("RX: MB{} - {:?}", data.mailbox_number, data.frame);
+            }
+
+            Systick::delay(1.millis()).await;
+        }
+    }
+
+    #[task(shared = [can])]
+    async fn run_can_tx(cx: run_can_tx::Context) {
+        let run_can_tx::SharedResources { mut can, .. } = cx.shared;
         // create a `Frame` with `StandardID` 0x00
         // and `Data` [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
-        let id = imxrt_hal::can::Id::from(imxrt_hal::can::StandardId::new(0x00).unwrap());
-        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let id = imxrt_hal::can::Id::from(imxrt_hal::can::StandardId::new(0x03).unwrap());
+        let data: [u8; 1] = [0x03];
         let frame = imxrt_hal::can::Frame::new_data(id, data);
 
         loop {
             // read all available mailboxes for any available frames
-            can.read_mailboxes();
-
-            // transmit the frame
-            can.transmit(&frame);
-            log::info!("Transmit");
-
+            can.lock(|can| can.transmit(&frame));
             Systick::delay(1000.millis()).await;
         }
     }
@@ -145,36 +155,36 @@ mod app {
     ///
     /// You won't see all the log levels until you configure your build. See the
     /// top-level docs for more information.
-    #[task(local = [led])]
-    async fn make_logs(cx: make_logs::Context) {
-        let make_logs::LocalResources { led, .. } = cx.local;
+    // #[task(local = [led])]
+    // async fn make_logs(cx: make_logs::Context) {
+    //     let make_logs::LocalResources { led, .. } = cx.local;
 
-        let mut counter = 0u32;
-        loop {
-            led.toggle();
-            Systick::delay(250.millis()).await;
+    //     let mut counter = 0u32;
+    //     loop {
+    //         led.toggle();
+    //         Systick::delay(250.millis()).await;
 
-            log::trace!("TRACE: {}", counter);
+    //         log::trace!("TRACE: {}", counter);
 
-            if counter % 3 == 0 {
-                log::debug!("DEBUG: {}", counter);
-            }
+    //         if counter % 3 == 0 {
+    //             log::debug!("DEBUG: {}", counter);
+    //         }
 
-            if counter % 5 == 0 {
-                log::info!("INFO: {}", counter);
-            }
+    //         if counter % 5 == 0 {
+    //             log::info!("INFO: {}", counter);
+    //         }
 
-            if counter % 7 == 0 {
-                log::warn!("WARN: {}", counter);
-            }
+    //         if counter % 7 == 0 {
+    //             log::warn!("WARN: {}", counter);
+    //         }
 
-            if counter % 31 == 0 {
-                log::error!("ERROR: {}", counter);
-            }
+    //         if counter % 31 == 0 {
+    //             log::error!("ERROR: {}", counter);
+    //         }
 
-            counter = counter.wrapping_add(1);
-        }
-    }
+    //         counter = counter.wrapping_add(1);
+    //     }
+    // }
 
     /// This task runs when the USB1 interrupt activates.
     /// Simply poll the logger to control the logging process.
@@ -183,26 +193,14 @@ mod app {
         cx.local.poller.poll();
     }
 
-    //     #[task(local = [led, q_rx, blink_count])]
-    //     async fn blink(cx: blink::Context) {
-    //         if cx.local.q_rx.ready() {
-    //             let mut buffer = [0u8; 256];
-    //             for elem in buffer.iter_mut() {
-    //                 *elem = match cx.local.q_rx.dequeue() {
-    //                     None => break,
-    //                     Some(b) => b,
-    //                 };
-    //             }
-    //             let s = core::str::from_utf8(&buffer).unwrap();
-    //             log::info!("read: {}", s);
-    //         }
-    //
-    //         // Toggle the LED.
-    //         cx.local.led.toggle();
-    //
-    //         // Schedule the following blink.
-    //         blink::spawn_after(100_u32.millis()).unwrap();
-    //     }
+    #[task(local = [led])]
+    async fn blink(cx: blink::Context) {
+        loop {
+            // Toggle the LED.
+            cx.local.led.toggle();
+            Systick::delay(1000.millis()).await;
+        }
+    }
 
     //    #[task(shared = [can1])]
     //    async fn can1_init(mut cx: can1_init::Context) {

--- a/examples/rtic_can_log.rs
+++ b/examples/rtic_can_log.rs
@@ -2,7 +2,7 @@
 //!
 //! This example requires:
 //!
-//! - The `rtic` feature to be enabled.
+//! - The `rt` feature to be enabled.
 //! - a Can transceiver (such as the Texas Instruments SN65HVD230).
 //!
 //! Pinout:

--- a/examples/rtic_can_log.rs
+++ b/examples/rtic_can_log.rs
@@ -1,0 +1,156 @@
+//! Demonstrates how to use a FlexCAN peripheral..
+//!
+//! This example requires:
+//!
+//! - The `rtic` feature to be enabled.
+//! - a Can transceiver (such as the Texas Instruments SN65HVD230).
+//!
+//! Pinout:
+//!
+//! - Teensy 4 Pin 22 (CAN1 TX) to TX pin of CAN Transceiver
+//! - Teensy 4 Pin 23 (CAN2 RX) to RX pin of CAN Transceiver
+//!
+//!
+
+#![no_std]
+#![no_main]
+
+use teensy4_panic as _;
+mod usb_io;
+
+// Type aliases for the Queue we want to use.
+type Ty = u8;
+const CAP: usize = 256;
+type Queue = heapless::spsc::Queue<Ty, { CAP }>;
+type Consumer = heapless::spsc::Consumer<'static, Ty, { CAP }>;
+
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [LPUART8])]
+mod app {
+    use crate::{usb_io, Consumer, Queue};
+    use embedded_hal::digital::v2::OutputPin;
+    use teensy4_bsp as bsp;
+    use bsp::hal::iomuxc::consts::U1;
+
+    use dwt_systick_monotonic::{fugit::ExtU32, DwtSystick};
+
+    #[monotonic(binds = SysTick, default = true)]
+    type MyMono = DwtSystick<{ bsp::hal::ccm::PLL1::ARM_HZ }>;
+
+    #[local]
+    struct Local {
+        led: bsp::Led,
+        q_rx: Consumer,
+        blink_count: u32,
+    }
+
+    #[shared]
+    struct Shared {
+        can1: bsp::hal::can::CAN<U1>,
+    }
+
+    #[init(local = [
+        queue: Queue = heapless::spsc::Queue::new(),
+    ])]
+    fn init(mut cx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let mut dcb = cx.core.DCB;
+        let dwt = cx.core.DWT;
+        let systick = cx.core.SYST;
+
+        usb_io::init().unwrap();
+
+        let mono = DwtSystick::new(&mut dcb, dwt, systick, bsp::hal::ccm::PLL1::ARM_HZ);
+
+        cx.device.ccm.pll1.set_arm_clock(
+            bsp::hal::ccm::PLL1::ARM_HZ,
+            &mut cx.device.ccm.handle,
+            &mut cx.device.dcdc,
+        );
+
+        let pins = bsp::pins::t40::from_pads(cx.device.iomuxc);
+
+        let (can1_builder, _) = cx.device.can.clock(
+            &mut cx.device.ccm.handle,
+            bsp::hal::ccm::can::ClockSelect::Pll2,
+            bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
+        );
+
+        let can1: bsp::hal::can::CAN<U1> = can1_builder.build();
+
+        // The queue used for buffering bytes.
+        let (_q_tx, q_rx) = cx.local.queue.split();
+
+        // LED setup.
+        let mut led = bsp::configure_led(pins.p13);
+        led.set_high().unwrap();
+
+        // Schedule the first blink.
+        blink::spawn_after(1_u32.secs()).unwrap();
+
+        can1_init::spawn_after(1_u32.secs()).unwrap();
+
+        (
+            Shared { can1 },
+            Local {
+                led,
+                q_rx,
+                blink_count: 0,
+            },
+            init::Monotonics(mono),
+        )
+    }
+
+    #[task(local = [led, q_rx, blink_count])]
+    fn blink(cx: blink::Context) {
+        if cx.local.q_rx.ready() {
+            let mut buffer = [0u8; 256];
+            for elem in buffer.iter_mut() {
+                *elem = match cx.local.q_rx.dequeue() {
+                    None => break,
+                    Some(b) => b,
+                };
+            }
+            let s = core::str::from_utf8(&buffer).unwrap();
+            log::info!("read: {}", s);
+        }
+
+        // Toggle the LED.
+        cx.local.led.toggle();
+
+        // Schedule the following blink.
+        blink::spawn_after(100_u32.millis()).unwrap();
+    }
+
+    #[task(shared = [can1])]
+    fn can1_init(mut cx: can1_init::Context) {
+        cx.shared.can1.lock(|can1| {
+            can1.set_baud_rate(1_000_000);
+            can1.set_max_mailbox(16);
+            can1.enable_fifo();
+            can1.set_fifo_interrupt(true);
+            can1.set_fifo_accept_all();
+            can1.print_registers();
+        });
+        can1::spawn_after(100_u32.millis()).unwrap();
+    }
+
+    #[task(shared = [can1])]
+    fn can1(mut cx: can1::Context) {
+        let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let id = bsp::hal::can::Id::from(bsp::hal::can::StandardId::new(0x00).unwrap());
+        let frame = bsp::hal::can::Frame::new_data(id, data);
+        cx.shared.can1.lock(|can1| {
+            can1.transmit(&frame).ok();
+        });
+        can1::spawn_after(100_u32.millis()).unwrap();
+    }
+
+    #[task(binds = CAN1, shared = [can1],)]
+    fn can1_int(mut cx: can1_int::Context) {
+        cx.shared.can1.lock(|can1| {
+            match can1.handle_interrupt() {
+                Some(f) => log::info!("Rx: {:?}", &f),
+                None => { },
+            };
+        });
+    }
+}

--- a/examples/rtic_can_log.rs
+++ b/examples/rtic_can_log.rs
@@ -68,13 +68,13 @@ mod app {
 
         let pins = bsp::pins::t40::from_pads(cx.device.iomuxc);
 
-        let (can1_builder, _) = cx.device.can.clock(
-            &mut cx.device.ccm.handle,
-            bsp::hal::ccm::can::ClockSelect::Pll2,
+        let (can1_builder, _) = peripherals.can.clock(
+            &mut peripherals.ccm.handle,
+            bsp::hal::ccm::can::ClockSelect::OSC,
             bsp::hal::ccm::can::PrescalarSelect::DIVIDE_1,
         );
-
-        let can1: bsp::hal::can::CAN<U1> = can1_builder.build();
+    
+        let mut can1 = can1_builder.build(pins.p22, pins.p23);
 
         // The queue used for buffering bytes.
         let (_q_tx, q_rx) = cx.local.queue.split();

--- a/src/board.rs
+++ b/src/board.rs
@@ -361,30 +361,26 @@ pub type Lpi2c1 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P19, pins::co
 /// Use [`lpi2c`] to create this driver.
 pub type Lpi2c3 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P16, pins::common::P17>, 3>;
 
-
 /// FlexCAN peripheral
-/// 
+///
 
-
-pub fn flexcan<Tx, Rx, const N: u8>(
-    instance: ral::can::Instance<N>,
-    tx: Tx,
-    rx: Rx,
-) -> hal::can::CAN<N>
-where 
-    Tx: hal::iomuxc::flexcan::Pin<
-        Signal = hal::iomuxc::flexcan::Tx,
-        Module = hal::iomuxc::consts::Const<N>,
-    >,
-    Rx: hal::iomuxc::flexcan::Pin<
-        Signal = hal::iomuxc::flexcan::Rx,
-        Module = hal::iomuxc::consts::Const<N>,
-    >,
-{
-    let mut can = hal::can::CAN::new()
-}
-
-
+// pub fn flexcan<Tx, Rx, const N: u8>(
+//     instance: ral::can::Instance<N>,
+//     tx: Tx,
+//     rx: Rx,
+// ) -> hal::can::CAN<N>
+// where
+//     Tx: hal::iomuxc::flexcan::Pin<
+//         Signal = hal::iomuxc::flexcan::Tx,
+//         Module = hal::iomuxc::consts::Const<N>,
+//     >,
+//     Rx: hal::iomuxc::flexcan::Pin<
+//         Signal = hal::iomuxc::flexcan::Rx,
+//         Module = hal::iomuxc::consts::Const<N>,
+//     >,
+// {
+//     let mut can = hal::can::CAN::new()
+// }
 
 /// LPSPI4 peripheral.
 ///

--- a/src/board.rs
+++ b/src/board.rs
@@ -267,6 +267,8 @@ pub struct Resources<Pins> {
     pub flexio2: ral::flexio::FLEXIO2,
     /// The FlexIO3 register block.
     pub flexio3: ral::flexio::FLEXIO3,
+    /// The FlexCAN1 register block.
+    pub flexcan1: ral::can::CAN1,
     /// The register block for ADC1.
     ///
     /// ADC drivers constructed by `board` use a pre-configured clock and divisor. To change
@@ -358,6 +360,31 @@ pub type Lpi2c1 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P19, pins::co
 ///
 /// Use [`lpi2c`] to create this driver.
 pub type Lpi2c3 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P16, pins::common::P17>, 3>;
+
+
+/// FlexCAN peripheral
+/// 
+
+
+pub fn flexcan<Tx, Rx, const N: u8>(
+    instance: ral::can::Instance<N>,
+    tx: Tx,
+    rx: Rx,
+) -> hal::can::CAN<N>
+where 
+    Tx: hal::iomuxc::flexcan::Pin<
+        Signal = hal::iomuxc::flexcan::Tx,
+        Module = hal::iomuxc::consts::Const<N>,
+    >,
+    Rx: hal::iomuxc::flexcan::Pin<
+        Signal = hal::iomuxc::flexcan::Rx,
+        Module = hal::iomuxc::consts::Const<N>,
+    >,
+{
+    let mut can = hal::can::CAN::new()
+}
+
+
 
 /// LPSPI4 peripheral.
 ///
@@ -607,6 +634,7 @@ fn prepare_resources<Pins>(
         flexpwm2: hal::flexpwm::new(instances.PWM2),
         flexpwm3: hal::flexpwm::new(instances.PWM3),
         flexpwm4: hal::flexpwm::new(instances.PWM4),
+        flexcan1: instances.CAN1,
         adc1,
         adc2,
         trng,

--- a/src/board.rs
+++ b/src/board.rs
@@ -135,6 +135,7 @@
 
 use crate::{hal, pins, ral};
 use core::sync::atomic::{AtomicBool, Ordering};
+pub use hal::can::Pins as CanPins;
 pub use hal::lpspi::Pins as LpspiPins;
 
 /// Use [`instances()`] to safely acquire.
@@ -269,6 +270,8 @@ pub struct Resources<Pins> {
     pub flexio3: ral::flexio::FLEXIO3,
     /// The FlexCAN1 register block.
     pub flexcan1: ral::can::CAN1,
+    /// The FlexCAN1 register block.
+    pub flexcan2: ral::can::CAN2,
     /// The register block for ADC1.
     ///
     /// ADC drivers constructed by `board` use a pre-configured clock and divisor. To change
@@ -362,25 +365,40 @@ pub type Lpi2c1 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P19, pins::co
 pub type Lpi2c3 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P16, pins::common::P17>, 3>;
 
 /// FlexCAN peripheral
-///
+pub fn flexcan<Tx, Rx, const N: u8>(
+    instance: ral::can::Instance<N>,
+    tx: Tx,
+    rx: Rx,
+) -> hal::can::CAN<CanPins<Tx, Rx>, N>
+where
+    Tx: hal::iomuxc::flexcan::Pin<
+        Signal = hal::iomuxc::flexcan::Tx,
+        Module = hal::iomuxc::consts::Const<N>,
+    >,
+    Rx: hal::iomuxc::flexcan::Pin<
+        Signal = hal::iomuxc::flexcan::Rx,
+        Module = hal::iomuxc::consts::Const<N>,
+    >,
+{
+    let can = hal::can::CAN::new(instance, tx, rx, CAN_FREQUENCY);
+    can
+}
 
-// pub fn flexcan<Tx, Rx, const N: u8>(
-//     instance: ral::can::Instance<N>,
-//     tx: Tx,
-//     rx: Rx,
-// ) -> hal::can::CAN<N>
-// where
-//     Tx: hal::iomuxc::flexcan::Pin<
-//         Signal = hal::iomuxc::flexcan::Tx,
-//         Module = hal::iomuxc::consts::Const<N>,
-//     >,
-//     Rx: hal::iomuxc::flexcan::Pin<
-//         Signal = hal::iomuxc::flexcan::Rx,
-//         Module = hal::iomuxc::consts::Const<N>,
-//     >,
-// {
-//     let mut can = hal::can::CAN::new()
-// }
+/// FlexCAN1 peripheral
+///
+/// - Pin 22 is TX
+/// - Pin 23 is RX
+///
+/// use [`flexcan`] to create this driver.
+pub type Flexcan1 = hal::can::CAN<CanPins<pins::common::P22, pins::common::P23>, 1>;
+
+/// FlexCAN2 peripheral
+///
+/// - Pin 1 is TX
+/// - Pin 0 is RX
+///
+/// use [`flexcan`] to create this driver.
+pub type Flexcan2 = hal::can::CAN<CanPins<pins::common::P1, pins::common::P0>, 2>;
 
 /// LPSPI4 peripheral.
 ///
@@ -631,6 +649,7 @@ fn prepare_resources<Pins>(
         flexpwm3: hal::flexpwm::new(instances.PWM3),
         flexpwm4: hal::flexpwm::new(instances.PWM4),
         flexcan1: instances.CAN1,
+        flexcan2: instances.CAN2,
         adc1,
         adc2,
         trng,

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -173,6 +173,17 @@ fn setup_lpspi_clk(ccm: &mut ral::ccm::CCM) {
     ccm::lpspi_clk::set_divider(ccm, LPSPI_DIVIDER);
 }
 
+// Set up CAN clock root
+const CAN_DIVIDER: u32 = 1;
+pub const CAN_FREQUENCY: u32 = ccm::XTAL_OSCILLATOR_HZ / CAN_DIVIDER;
+fn setup_can_clk(ccm: &mut ral::ccm::CCM) {
+    clock_gate::FLEXCAN_CLOCK_GATES
+        .iter()
+        .for_each(|locator| locator.set(ccm, clock_gate::OFF));
+    ccm::can_clk::set_selection(ccm, ccm::can_clk::Selection::Oscillator);
+    ccm::can_clk::set_divider(ccm, CAN_DIVIDER);
+}
+
 const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::pit(),
     clock_gate::gpt_bus::<1>(),
@@ -201,6 +212,10 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::flexpwm::<2>(),
     clock_gate::flexpwm::<3>(),
     clock_gate::flexpwm::<4>(),
+    clock_gate::can::<1>(),
+    clock_gate::can::<2>(),
+    clock_gate::can_pe::<1>(),
+    clock_gate::can_pe::<2>(),
     clock_gate::flexio::<1>(),
     clock_gate::flexio::<2>(),
     clock_gate::flexio::<3>(),
@@ -227,7 +242,7 @@ pub fn prepare_clocks_and_power(
     setup_lpspi_clk(ccm);
     setup_perclk_clk(ccm);
     setup_uart_clk(ccm);
-    setup_flexcan_clk(ccm);
+    setup_can_clk(ccm);
 
     CLOCK_GATES
         .iter()

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -227,6 +227,7 @@ pub fn prepare_clocks_and_power(
     setup_lpspi_clk(ccm);
     setup_perclk_clk(ccm);
     setup_uart_clk(ccm);
+    setup_flexcan_clk(ccm);
 
     CLOCK_GATES
         .iter()


### PR DESCRIPTION
This PR adds BSP support for the FlexCAN1 and FlexCAN2 interfaces added in this PR for `imxrt-hal`: [#171](https://github.com/imxrt-rs/imxrt-hal/pull/171)

FlexCAN1 interface has been tested in HW using a Teensy4.1.

More than happy to take any code comments / improvement suggestions!

Acknowledgements:
The vast majority of this work is from @dstric-aqueduct - who wrote the initial FlexCAN peripheral code in https://github.com/imxrt-rs/imxrt-hal/pull/122.

@SebKuzminsky rebased @dstric-aqueduct's work onto imxrt-hal 0.5 which gave me a great starting point to work from.