### PR TITLE
Add missing lpspi instances

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -239,6 +239,8 @@ pub struct Resources<Pins> {
     pub lpi2c1: ral::lpi2c::LPI2C1,
     /// The register block for [`Lpi2c3`].
     pub lpi2c3: ral::lpi2c::LPI2C3,
+    /// The register blocks for [`Lpspi1`].
+    pub lpspi1: ral::lpspi::LPSPI1,
     /// The register blocks for [`Lpspi3`].
     pub lpspi3: ral::lpspi::LPSPI3,
     /// The register block for [`Lpspi4`].
@@ -360,6 +362,16 @@ pub type Lpi2c1 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P19, pins::co
 ///
 /// Use [`lpi2c`] to create this driver.
 pub type Lpi2c3 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P16, pins::common::P17>, 3>;
+
+/// LPSPI1 peripheral.
+///
+/// - SDO:  GPIO_SD_B0_02 (p43) or GPIO_EMC_28 (p50)
+/// - SDI:  GPIO_SD_B0_03 (p42) or GPIO_EMC_29 (p54)
+/// - SCK:  GPIO_SD_B0_00 (p45) or GPIO_EMC_27 (p49)
+/// - PCS0: GPIO_SD_B0_01 (p44) or GPIO_EMC_30
+///
+/// Use [`lpspi`] to create this driver.
+pub type Lpspi1<SDO, SDI, SCK, PCS0> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK, PCS0>, 1>;
 
 /// LPSPI3 peripheral.
 ///
@@ -608,6 +620,7 @@ fn prepare_resources<Pins>(
         pins,
         lpi2c1: instances.LPI2C1,
         lpi2c3: instances.LPI2C3,
+        lpspi1: instances.LPSPI1,
         lpspi3: instances.LPSPI3,
         lpspi4: instances.LPSPI4,
         lpuart6: instances.LPUART6,

--- a/src/board.rs
+++ b/src/board.rs
@@ -241,6 +241,8 @@ pub struct Resources<Pins> {
     pub lpi2c3: ral::lpi2c::LPI2C3,
     /// The register blocks for [`Lpspi1`].
     pub lpspi1: ral::lpspi::LPSPI1,
+    /// The register blocks for [`Lpspi2`].
+    pub lpspi2: ral::lpspi::LPSPI2,
     /// The register blocks for [`Lpspi3`].
     pub lpspi3: ral::lpspi::LPSPI3,
     /// The register block for [`Lpspi4`].
@@ -372,6 +374,16 @@ pub type Lpi2c3 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P16, pins::co
 ///
 /// Use [`lpspi`] to create this driver.
 pub type Lpspi1<SDO, SDI, SCK, PCS0> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK, PCS0>, 1>;
+
+/// LPSPI2 peripheral.
+///
+/// - SDO:  GPIO_SD_B1_08 or GPIO_EMC_02
+/// - SDI:  GPIO_SD_B1_09 or GPIO_EMC_03
+/// - SCK:  GPIO_SD_B1_07 or GPIO_EMC_00
+/// - PCS0: GPIO_SD_B1_06 or GPIO_EMC_01
+///
+/// Use [`lpspi`] to create this driver.
+pub type Lpspi2<SDO, SDI, SCK, PCS0> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK, PCS0>, 2>;
 
 /// LPSPI3 peripheral.
 ///
@@ -621,6 +633,7 @@ fn prepare_resources<Pins>(
         lpi2c1: instances.LPI2C1,
         lpi2c3: instances.LPI2C3,
         lpspi1: instances.LPSPI1,
+        lpspi2: instances.LPSPI2,
         lpspi3: instances.LPSPI3,
         lpspi4: instances.LPSPI4,
         lpuart6: instances.LPUART6,

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -189,6 +189,8 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::snvs_hp(),
     clock_gate::lpi2c::<1>(),
     clock_gate::lpi2c::<3>(),
+    clock_gate::lpspi::<1>(),
+    clock_gate::lpspi::<2>(),
     clock_gate::lpspi::<3>(),
     clock_gate::lpspi::<4>(),
     clock_gate::lpuart::<6>(),


### PR DESCRIPTION
This adds support for LPSPI1 and LPSPI2.

LPSPI1 is available on the pins of Teensy 4.1, but LPSPI2 is not.  I'm requesting to add both because it makes it easier to derive BSPs for new boards from teensy4-rs. 