### PR TITLE
Add SAI/I2S audio support with Audio PLL and SGTL5000 examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 /out
 /svd/imxrt1062/*
 .vscode/
+.claude/
 
 # Let developers specify their own configs in non Teensy crates
 imxrt1062-fcb-gen/.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,11 @@ members = [
 
 [workspace.dependencies]
 imxrt-boot-gen = { version = "0.3.0", features = ["imxrt1060"] }
-imxrt-hal = { version = "0.5.3", features = ["imxrt1060"] }
-imxrt-iomuxc = { version = "0.2.0", features = ["imxrt1060"] }
-imxrt-log = { version = "0.1" }
-imxrt-ral = { version = "0.5", features = ["imxrt1062"] }
-imxrt-rt = { version = "0.1.4", features = ["device"] }
+imxrt-hal = { path = "../imxrt-hal", features = ["imxrt1060"] }
+imxrt-iomuxc = { version = "0.3.0", features = ["imxrt1060"] }
+imxrt-log = { path = "../imxrt-hal/logging", default-features = false }
+imxrt-ral = { path = "../imxrt-ral", features = ["imxrt1062"] }
+imxrt-rt = { version = "0.1.5", features = ["device"] }
 
 [features]
 rt = ["dep:imxrt-rt", "imxrt-ral/rt"]
@@ -101,8 +101,8 @@ log = "0.4"
 nb = "1"
 rtic = { version = "2", features = ["thumbv7-backend"] }
 rtic-monotonics = { version = "1", default-features = false, features = ["cortex-m-systick"] }
-usb-device = "0.2"
-usbd-serial = "0.1"
+usb-device = "0.3"
+usbd-serial = "0.2"
 
 [[example]]
 name = "blocking_gpt"
@@ -151,3 +151,17 @@ required-features = ["rt"]
 [[example]]
 name = "rtic_usb_log"
 required-features = ["rt"]
+
+[[example]]
+name = "rtic_sai_dma_tone"
+required-features = ["rt"]
+
+[[example]]
+name = "rtic_sai_poll_tone"
+required-features = ["rt"]
+
+[patch.crates-io.imxrt-ral]
+path = "../imxrt-ral"
+
+[patch.crates-io.imxrt-iomuxc]
+git = "https://github.com/imxrt-rs/imxrt-iomuxc"

--- a/examples/rtic_defmt_usb_log.rs
+++ b/examples/rtic_defmt_usb_log.rs
@@ -57,7 +57,9 @@ mod app {
 
     use usb_device::{
         bus::UsbBusAllocator,
-        device::{UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid},
+        device::{
+            StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid,
+        },
     };
     use usbd_serial::SerialPort;
 
@@ -131,7 +133,8 @@ mod app {
         let usb_bus = cx.local.usb_bus.insert(UsbBusAllocator::new(bus_adapter));
         let usb_class = SerialPort::new(usb_bus);
         let usb_device = UsbDeviceBuilder::new(usb_bus, VID_PID)
-            .product(PRODUCT)
+            .strings(&[StringDescriptors::default().product(PRODUCT)])
+            .unwrap()
             .device_class(usbd_serial::USB_CLASS_CDC)
             .build();
 

--- a/examples/rtic_lpspi.rs
+++ b/examples/rtic_lpspi.rs
@@ -35,7 +35,7 @@ mod app {
     /// These resources are local to individual tasks.
     #[local]
     struct Local {
-        lpspi3: board::Lpspi3<teensy4_bsp::pins::common::P1, teensy4_bsp::pins::common::P0>,
+        lpspi3: board::Lpspi3<teensy4_bsp::pins::common::P1>,
 
         /// Note: lpspi4 SCK is on pin 13 which collides with the Teensy 4/4.1 LED
         lpspi4: board::Lpspi4,
@@ -64,7 +64,6 @@ mod app {
                 sdo: pins.p26,
                 sdi: pins.p1,
                 sck: pins.p27,
-                pcs0: pins.p0,
             },
             1_000_000,
         );
@@ -79,7 +78,6 @@ mod app {
                 sdo: pins.p11,
                 sdi: pins.p12,
                 sck: pins.p13,
-                pcs0: pins.p10,
             },
             1_000_000,
         );

--- a/examples/rtic_sai_dma_tone.rs
+++ b/examples/rtic_sai_dma_tone.rs
@@ -1,0 +1,341 @@
+//! SAI1 DMA tone generator for the Teensy Audio Shield (SGTL5000).
+//!
+//! Plays a continuous 440 Hz triangular-ish tone through the headphone
+//! output of the Teensy Audio Shield (Rev D) using DMA-driven I2S via SAI1.
+//!
+//! This example verifies the Phase 0 HAL prerequisites:
+//! - Audio PLL (PLL4) clocking SAI1
+//! - SAI clock gates enabled
+//! - SAI DMA peripheral traits (`Destination<u32>` for `Tx`)
+//! - SGTL5000 basic initialisation via I2C
+//!
+//! Hardware: Teensy 4.1 + Audio Shield Rev D (SGTL5000)
+//! Pins used:
+//!   - p23: SAI1_MCLK
+//!   - p26: SAI1_TX_BCLK
+//!   - p27: SAI1_TX_SYNC (LRCLK)
+//!   - p7:  SAI1_TX_DATA0
+//!   - p20: SAI1_RX_SYNC
+//!   - p21: SAI1_RX_BCLK
+//!   - p8:  SAI1_RX_DATA0
+//!   - p18: LPI2C1_SDA (SGTL5000 control)
+//!   - p19: LPI2C1_SCL (SGTL5000 control)
+
+#![no_std]
+#![no_main]
+
+use teensy4_panic as _;
+
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [KPP])]
+mod app {
+    use bsp::board;
+    use bsp::hal;
+    use bsp::ral;
+    use teensy4_bsp as bsp;
+
+    use hal::dma::{
+        channel::{self, Channel, Configuration},
+        peripheral::Destination,
+    };
+
+    use embedded_hal::blocking::i2c::Write as I2cWrite;
+
+    // ── Audio constants ──────────────────────────────────────────────
+
+    /// Number of stereo samples per DMA buffer.
+    const AUDIO_BLOCK_SAMPLES: usize = 128;
+
+    /// DMA buffer length in u32 words (L + R interleaved).
+    const DMA_BUF_LEN: usize = AUDIO_BLOCK_SAMPLES * 2;
+
+    /// 256-entry waveform lookup table (triangle approximation of sine).
+    ///
+    /// Built at compile time with pure integer math (no floats, no libm).
+    /// Amplitude ±32256 (Q15-ish). Sounds a bit buzzy but is perfectly
+    /// adequate for verifying end-to-end audio output.
+    static WAVE_TABLE: [i16; 256] = {
+        let mut table = [0i16; 256];
+        let mut i: usize = 0;
+        while i < 256 {
+            let phase = i as i32; // 0..255 ≙ 0..2π
+
+            // quarter-wave index and sign
+            let (idx, negate) = if phase < 64 {
+                (phase, false)
+            } else if phase < 128 {
+                (128 - phase, false)
+            } else if phase < 192 {
+                (phase - 128, true)
+            } else {
+                (256 - phase, true)
+            };
+            // idx ∈ 0..64.  Triangle: ramp linearly
+            let val: i16 = if idx <= 32 {
+                (idx as i16) * 1008 // 0 → 32256
+            } else {
+                ((64 - idx) as i16) * 1008
+            };
+            table[i] = if negate { -val } else { val };
+            i += 1;
+        }
+        table
+    };
+
+    // ── Type aliases ─────────────────────────────────────────────────
+
+    type SaiTx = hal::sai::Tx<1, 32, 2, hal::sai::PackingNone>;
+
+    // ── RTIC resources ───────────────────────────────────────────────
+
+    #[local]
+    struct Local {
+        led: board::Led,
+        dma_chan: Channel,
+        sai_tx: SaiTx,
+        phase: u32,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    // ── Static DMA buffer ────────────────────────────────────────────
+    // Place in OCRAM (.uninit region) which is non-cached and
+    // DMA-accessible. Using .uninit means the section is NOLOAD so it
+    // won't bloat the flash image / hex file. The buffer is filled
+    // before every DMA transfer, so uninitialised contents are fine.
+    #[link_section = ".uninit.dmabuffers"]
+    static mut DMA_BUF: core::mem::MaybeUninit<[u32; DMA_BUF_LEN]> =
+        core::mem::MaybeUninit::uninit();
+
+    // ── Init ─────────────────────────────────────────────────────────
+
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let board::Resources {
+            mut gpio2,
+            pins,
+            mut dma,
+            sai1,
+            lpi2c1,
+            ..
+        } = board::t41(cx.device);
+
+        // LED for heartbeat
+        let led = board::led(&mut gpio2, pins.p13);
+
+        // ── MCLK direction: output on pin 23 ────────────────────────
+        unsafe {
+            let gpr = ral::iomuxc_gpr::IOMUXC_GPR::instance();
+            ral::modify_reg!(ral::iomuxc_gpr, gpr, GPR1, SAI1_MCLK_DIR: 1);
+        }
+
+        // ── Configure SAI1 ──────────────────────────────────────────
+        // SAI must be configured and RX enabled BEFORE the SGTL5000 is
+        // initialised — the codec needs MCLK present to respond on I2C.
+        let sai = hal::sai::Sai::new(
+            sai1,
+            pins.p23, // MCLK
+            hal::sai::Pins {
+                sync: pins.p27, // TX_SYNC (LRCLK)
+                bclk: pins.p26, // TX_BCLK
+                data: pins.p7,  // TX_DATA0
+            },
+            hal::sai::Pins {
+                sync: pins.p20, // RX_SYNC
+                bclk: pins.p21, // RX_BCLK
+                data: pins.p8,  // RX_DATA0
+            },
+        );
+
+        let sai_config = {
+            // bclk_div(4) → BCLK = MCLK/4 ≈ 2.8 MHz = 64×Fs
+            // This matches Teensyduino (32-bit words, 64×Fs).
+            let mut c = hal::sai::SaiConfig::i2s(hal::sai::bclk_div(4));
+            c.sync_mode = hal::sai::SyncMode::TxFollowRx;
+            // Select1 = MSEL 0b01 = MCLK1 (PLL4-derived, ~11.3 MHz).
+            // The default Sysclk = MSEL 0b00 = IPG bus clock (150 MHz),
+            // which is ~13x too fast.
+            c.mclk_source = hal::sai::MclkSource::Select1;
+            c
+        };
+        let (Some(mut sai_tx), Some(mut sai_rx)) =
+            sai.split::<32, 2, hal::sai::PackingNone>(&sai_config)
+        else {
+            panic!("SAI split failed");
+        };
+
+        // Enable RX (clock master with TxFollowRx) so that BCLK and LRCLK
+        // are present on the pins for the SGTL5000 during I2C init.
+        sai_rx.set_enable(true);
+
+        // ── I2C for SGTL5000 control ────────────────────────────────
+        let mut i2c: board::Lpi2c1 = board::lpi2c(
+            lpi2c1,
+            pins.p19,
+            pins.p18,
+            board::Lpi2cClockSpeed::KHz400,
+        );
+
+        // ── Initialise SGTL5000 codec ───────────────────────────────
+        sgtl5000_init(&mut i2c);
+
+        // ── DMA channel 0 for SAI1 TX ───────────────────────────────
+        let mut dma_chan = dma[0].take().expect("DMA channel 0");
+
+        // Fill the initial tone buffer
+        let phase = fill_tone_buffer(0);
+
+        // Programme TCD: linear source buffer → hardware SAI TDR
+        dma_chan.disable();
+        dma_chan.set_disable_on_completion(true);
+        dma_chan.set_interrupt_on_completion(true);
+        dma_chan.set_channel_configuration(Configuration::enable(
+            sai_tx.destination_signal(),
+        ));
+        unsafe {
+            let buf = core::slice::from_raw_parts(
+                core::ptr::addr_of!(DMA_BUF) as *const u32,
+                DMA_BUF_LEN,
+            );
+            channel::set_source_linear_buffer(&mut dma_chan, buf);
+            channel::set_destination_hardware(&mut dma_chan, sai_tx.destination_address());
+            dma_chan.set_minor_loop_bytes(core::mem::size_of::<u32>() as u32);
+            dma_chan.set_transfer_iterations(DMA_BUF_LEN as u16);
+        }
+
+        // Enable SAI TX DMA requests first, then start DMA, then enable
+        // the transmitter. This order avoids a brief FIFO underrun at
+        // startup.
+        sai_tx.enable_dma_transmit();
+        unsafe { dma_chan.enable() };
+        sai_tx.set_enable(true);
+
+        (
+            Shared {},
+            Local {
+                led,
+                dma_chan,
+                sai_tx,
+                phase,
+            },
+        )
+    }
+
+    // ── DMA channel 0 completion ISR ─────────────────────────────────
+
+    #[task(binds = DMA0_DMA16, local = [led, dma_chan, sai_tx, phase, toggle: u32 = 0], priority = 2)]
+    fn dma_complete(cx: dma_complete::Context) {
+        let dma_chan = cx.local.dma_chan;
+        let phase = cx.local.phase;
+        let led = cx.local.led;
+        let toggle = cx.local.toggle;
+
+        // Acknowledge interrupt
+        while dma_chan.is_interrupt() {
+            dma_chan.clear_interrupt();
+        }
+        dma_chan.clear_complete();
+
+        // Toggle LED as heartbeat (~1.3 Hz with 128-sample buffers @ 44 kHz)
+        *toggle += 1;
+        if *toggle % 172 == 0 {
+            led.toggle();
+        }
+
+        // Fill buffer with next block of tone samples
+        *phase = fill_tone_buffer(*phase);
+
+        // Re-arm DMA
+        unsafe {
+            let buf = core::slice::from_raw_parts(
+                core::ptr::addr_of!(DMA_BUF) as *const u32,
+                DMA_BUF_LEN,
+            );
+            channel::set_source_linear_buffer(&mut *dma_chan, buf);
+            dma_chan.set_transfer_iterations(DMA_BUF_LEN as u16);
+            dma_chan.enable();
+        }
+    }
+
+    // ── Helper: fill DMA buffer with 440 Hz tone ─────────────────────
+
+    /// Phase-accumulator increment for 440 Hz at Fs ≈ 44 117.656 Hz.
+    ///
+    /// `440 * 65536 / 44118 ≈ 653`.  We use a Q16 accumulator whose top
+    /// 8 bits index the 256-entry wave table.
+    const PHASE_INC: u32 = 653;
+
+    fn fill_tone_buffer(mut phase: u32) -> u32 {
+        let buf = unsafe {
+            core::slice::from_raw_parts_mut(
+                core::ptr::addr_of_mut!(DMA_BUF) as *mut u32,
+                DMA_BUF_LEN,
+            )
+        };
+        for i in 0..AUDIO_BLOCK_SAMPLES {
+            let idx = ((phase >> 8) & 0xFF) as usize;
+            let sample = WAVE_TABLE[idx];
+            // 16-bit sample → upper 16 bits of 32-bit I2S word (MSB-aligned).
+            let sample32 = (sample as u16 as u32) << 16;
+
+            // Stereo: identical sample on both channels
+            buf[i * 2] = sample32;     // Left
+            buf[i * 2 + 1] = sample32; // Right
+
+            phase = phase.wrapping_add(PHASE_INC);
+        }
+        phase
+    }
+
+    // ── SGTL5000 I2C helpers ─────────────────────────────────────────
+
+    fn sgtl5000_write<I2C: I2cWrite>(i2c: &mut I2C, reg: u16, val: u16)
+    where
+        I2C::Error: core::fmt::Debug,
+    {
+        let buf = [
+            (reg >> 8) as u8,
+            reg as u8,
+            (val >> 8) as u8,
+            val as u8,
+        ];
+        i2c.write(0x0A, &buf).unwrap();
+    }
+
+    fn sgtl5000_init<I2C: I2cWrite>(i2c: &mut I2C)
+    where
+        I2C::Error: core::fmt::Debug,
+    {
+        // ── Power-up phase ──────────────────────────────────────
+        sgtl5000_write(i2c, 0x0030, 0x4060); // CHIP_ANA_POWER
+        sgtl5000_write(i2c, 0x0026, 0x006C); // CHIP_LINREG_CTRL
+        sgtl5000_write(i2c, 0x0028, 0x01F2); // CHIP_REF_CTRL
+        sgtl5000_write(i2c, 0x002C, 0x0F22); // CHIP_LINE_OUT_CTRL
+        sgtl5000_write(i2c, 0x003C, 0x4446); // CHIP_SHORT_CTRL
+        sgtl5000_write(i2c, 0x0024, 0x0137); // CHIP_ANA_CTRL: mute all
+        sgtl5000_write(i2c, 0x0030, 0x40FF); // CHIP_ANA_POWER: all on
+        sgtl5000_write(i2c, 0x0002, 0x0073); // CHIP_DIG_POWER
+
+        // Wait 400ms for VAG ramp & analog power-up (matches C++ delay(400)).
+        cortex_m::asm::delay(240_000_000);
+
+        // ── Volume & line-out ───────────────────────────────────
+        sgtl5000_write(i2c, 0x002E, 0x1D1D); // CHIP_LINE_OUT_VOL
+
+        // ── Clock & I2S configuration ───────────────────────────
+        sgtl5000_write(i2c, 0x0004, 0x0004); // CHIP_CLK_CTRL: 44.1 kHz
+        sgtl5000_write(i2c, 0x0006, 0x0030); // CHIP_I2S_CTRL: 16-bit I2S
+
+        // ── Signal routing ──────────────────────────────────────
+        sgtl5000_write(i2c, 0x000A, 0x0010); // CHIP_SSS_CTRL: I2S→DAC
+        sgtl5000_write(i2c, 0x000E, 0x0000); // CHIP_ADCDAC_CTRL: unmute DAC
+        sgtl5000_write(i2c, 0x0010, 0x3C3C); // CHIP_DAC_VOL: 0 dB
+        sgtl5000_write(i2c, 0x0022, 0x1818); // CHIP_ANA_HP_CTRL: HP vol 0 dB
+        sgtl5000_write(i2c, 0x0020, 0x0000); // CHIP_ANA_ADC_CTRL: ADC vol 0 dB
+
+        // ── Unmute headphones ───────────────────────────────────
+        // MUTE_LO=1, SELECT_HP=0(DAC), EN_ZCD_HP=1, MUTE_HP=0,
+        // SELECT_ADC=1, EN_ZCD_ADC=1, MUTE_ADC=0
+        sgtl5000_write(i2c, 0x0024, 0x0126); // CHIP_ANA_CTRL: unmute HP
+    }
+}

--- a/examples/rtic_sai_poll_tone.rs
+++ b/examples/rtic_sai_poll_tone.rs
@@ -1,0 +1,278 @@
+//! SAI1 polling tone generator for the Teensy Audio Shield (SGTL5000).
+//!
+//! Plays a continuous 440 Hz triangle tone through the headphone output
+//! using polled FIFO writes — **no DMA involved**. This is a minimal
+//! "does the audio board work at all?" sanity check.
+//!
+//! The SAI1 FIFO Request interrupt fires when the transmit FIFO drops
+//! to or below the watermark.  The ISR writes one stereo frame at a
+//! time until the FIFO is full.
+//!
+//! Hardware: Teensy 4.1 + Audio Shield Rev D (SGTL5000)
+//! Pins:
+//!   - p23  SAI1_MCLK
+//!   - p26  SAI1_TX_BCLK
+//!   - p27  SAI1_TX_SYNC (LRCLK)
+//!   - p7   SAI1_TX_DATA0
+//!   - p20  SAI1_RX_SYNC
+//!   - p21  SAI1_RX_BCLK
+//!   - p8   SAI1_RX_DATA0
+//!   - p18  LPI2C1_SDA
+//!   - p19  LPI2C1_SCL
+
+#![no_std]
+#![no_main]
+
+use teensy4_panic as _;
+
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [KPP])]
+mod app {
+    use bsp::board;
+    use bsp::hal;
+    use bsp::ral;
+    use teensy4_bsp as bsp;
+
+    use embedded_hal::blocking::i2c::Write as I2cWrite;
+
+    // ── Audio constants ──────────────────────────────────────────────
+
+    /// 256-entry triangle wave table.  Amplitude ±32256.
+    static WAVE_TABLE: [i16; 256] = {
+        let mut table = [0i16; 256];
+        let mut i: usize = 0;
+        while i < 256 {
+            let phase = i as i32;
+            let (idx, negate) = if phase < 64 {
+                (phase, false)
+            } else if phase < 128 {
+                (128 - phase, false)
+            } else if phase < 192 {
+                (phase - 128, true)
+            } else {
+                (256 - phase, true)
+            };
+            let val: i16 = if idx <= 32 {
+                (idx as i16) * 1008
+            } else {
+                ((64 - idx) as i16) * 1008
+            };
+            table[i] = if negate { -val } else { val };
+            i += 1;
+        }
+        table
+    };
+
+    // ── Type aliases ─────────────────────────────────────────────────
+
+    type SaiTx = hal::sai::Tx<1, 32, 2, hal::sai::PackingNone>;
+
+    // ── RTIC resources ───────────────────────────────────────────────
+
+    #[local]
+    struct Local {
+        led: board::Led,
+        sai_tx: SaiTx,
+        phase: u32,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    // ── Init ─────────────────────────────────────────────────────────
+
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let board::Resources {
+            mut gpio2,
+            pins,
+            sai1,
+            lpi2c1,
+            ..
+        } = board::t41(cx.device);
+
+        // LED for heartbeat
+        let led = board::led(&mut gpio2, pins.p13);
+
+        // ── MCLK direction: output on pin 23 ────────────────────────
+        unsafe {
+            let gpr = ral::iomuxc_gpr::IOMUXC_GPR::instance();
+            ral::modify_reg!(ral::iomuxc_gpr, gpr, GPR1, SAI1_MCLK_DIR: 1);
+        }
+
+        // ── Configure SAI1 ──────────────────────────────────────────
+        // SAI must be configured and RX enabled BEFORE the SGTL5000 is
+        // initialised — the codec needs MCLK present to respond on I2C.
+        let sai = hal::sai::Sai::new(
+            sai1,
+            pins.p23,
+            hal::sai::Pins {
+                sync: pins.p27,
+                bclk: pins.p26,
+                data: pins.p7,
+            },
+            hal::sai::Pins {
+                sync: pins.p20,
+                bclk: pins.p21,
+                data: pins.p8,
+            },
+        );
+
+        let sai_config = {
+            // bclk_div(4) → BCLK = MCLK/4 ≈ 2.8 MHz = 64×Fs
+            // This matches Teensyduino (32-bit words, 64×Fs).
+            let mut c = hal::sai::SaiConfig::i2s(hal::sai::bclk_div(4));
+            c.sync_mode = hal::sai::SyncMode::TxFollowRx;
+            // Select1 = MSEL 0b01 = MCLK1 (PLL4-derived, ~11.3 MHz).
+            // The default Sysclk = MSEL 0b00 = IPG bus clock (150 MHz),
+            // which is ~13x too fast.
+            c.mclk_source = hal::sai::MclkSource::Select1;
+            c
+        };
+        let (Some(mut sai_tx), Some(mut sai_rx)) =
+            sai.split::<32, 2, hal::sai::PackingNone>(&sai_config)
+        else {
+            panic!("SAI split failed");
+        };
+
+        // Pre-fill the FIFO with silence (zeros). Do NOT pre-fill with
+        // tone data — TX is not enabled yet, so the FIFO just holds these
+        // until the ISR starts producing real samples.
+        for _ in 0..16 {
+            sai_tx.write_frame(0, [0u32; 2]);
+        }
+
+        // Enable RX (clock master with TxFollowRx) so that BCLK and LRCLK
+        // are present on the pins for the SGTL5000 during I2C init.
+        sai_rx.set_enable(true);
+
+        // ── I2C for SGTL5000 control ────────────────────────────────
+        let mut i2c: board::Lpi2c1 = board::lpi2c(
+            lpi2c1,
+            pins.p19,
+            pins.p18,
+            board::Lpi2cClockSpeed::KHz400,
+        );
+
+        // ── Initialise SGTL5000 codec ───────────────────────────────
+        sgtl5000_init(&mut i2c);
+
+        // ── Enable TX & SAI1 interrupt ──────────────────────────────
+        // Enable FIFO Request Interrupt so the SAI1 ISR fires when
+        // the FIFO needs more data.
+        sai_tx.set_interrupts(hal::sai::Interrupts::FIFO_REQUEST);
+
+        // Enable TX now — FIFO is still full (pre-filled above, not
+        // draining because TX was deferred until here).
+        sai_tx.set_enable(true);
+
+        // Unmask SAI1 interrupt
+        unsafe { cortex_m::peripheral::NVIC::unmask(ral::interrupt::SAI1) };
+
+        (
+            Shared {},
+            Local {
+                led,
+                sai_tx,
+                phase: 0,
+            },
+        )
+    }
+
+    // ── Idle: blink LED to prove firmware is alive ─────────────────
+
+    #[idle(local = [led])]
+    fn idle(cx: idle::Context) -> ! {
+        loop {
+            cx.local.led.toggle();
+            // ~500 ms at 600 MHz  (3 cycles per iteration)
+            cortex_m::asm::delay(100_000_000);
+        }
+    }
+
+    // ── SAI1 FIFO-request ISR ────────────────────────────────────────
+
+    #[task(binds = SAI1, local = [sai_tx, phase], priority = 2)]
+    fn sai1_isr(cx: sai1_isr::Context) {
+        let sai_tx = cx.local.sai_tx;
+        let phase = cx.local.phase;
+
+        // Clear any error flags
+        let status = sai_tx.status();
+        if status.contains(hal::sai::Status::FIFO_ERROR) {
+            sai_tx.clear_status(hal::sai::Status::FIFO_ERROR);
+        }
+
+        // Push frames into the FIFO.
+        // The watermark is 16 words. When the IRQ fires (FIFO ≤ 16),
+        // there are at least 16 free slots (FIFO depth is 32).
+        // Each stereo frame = 2 words, so write 8 frames = 16 words
+        // to fill the FIFO without overflow.  Writing more would
+        // silently drop samples, causing phase jumps / chirps.
+        for _ in 0..8 {
+            let idx = ((*phase >> 8) & 0xFF) as usize;
+            let sample = WAVE_TABLE[idx];
+            // 16-bit sample → upper 16 bits of 32-bit I2S word (MSB-aligned).
+            let sample32 = (sample as u16 as u32) << 16;
+            sai_tx.write_frame(0, [sample32; 2]);
+            *phase = phase.wrapping_add(PHASE_INC);
+        }
+    }
+
+    // ── Tone generation constant ─────────────────────────────────────
+
+    /// Phase-accumulator increment for 440 Hz @ Fs ≈ 44 117 Hz.
+    /// 440 * 65536 / 44118 ≈ 653
+    const PHASE_INC: u32 = 653;
+
+    // ── SGTL5000 I2C helpers ─────────────────────────────────────────
+
+    fn sgtl5000_write<I2C: I2cWrite>(i2c: &mut I2C, reg: u16, val: u16)
+    where
+        I2C::Error: core::fmt::Debug,
+    {
+        let buf = [
+            (reg >> 8) as u8,
+            reg as u8,
+            (val >> 8) as u8,
+            val as u8,
+        ];
+        i2c.write(0x0A, &buf).unwrap();
+    }
+
+    fn sgtl5000_init<I2C: I2cWrite>(i2c: &mut I2C)
+    where
+        I2C::Error: core::fmt::Debug,
+    {
+        // ── Power-up phase ──────────────────────────────────────
+        sgtl5000_write(i2c, 0x0030, 0x4060); // CHIP_ANA_POWER
+        sgtl5000_write(i2c, 0x0026, 0x006C); // CHIP_LINREG_CTRL
+        sgtl5000_write(i2c, 0x0028, 0x01F2); // CHIP_REF_CTRL
+        sgtl5000_write(i2c, 0x002C, 0x0F22); // CHIP_LINE_OUT_CTRL
+        sgtl5000_write(i2c, 0x003C, 0x4446); // CHIP_SHORT_CTRL
+        sgtl5000_write(i2c, 0x0024, 0x0137); // CHIP_ANA_CTRL: mute all
+        sgtl5000_write(i2c, 0x0030, 0x40FF); // CHIP_ANA_POWER: all on
+        sgtl5000_write(i2c, 0x0002, 0x0073); // CHIP_DIG_POWER
+
+        // Wait 400ms for VAG ramp & analog power-up (matches C++ delay(400)).
+        cortex_m::asm::delay(240_000_000);
+
+        // ── Volume & line-out ───────────────────────────────────
+        sgtl5000_write(i2c, 0x002E, 0x1D1D); // CHIP_LINE_OUT_VOL
+
+        // ── Clock & I2S configuration ───────────────────────────
+        sgtl5000_write(i2c, 0x0004, 0x0004); // CHIP_CLK_CTRL: 44.1 kHz
+        sgtl5000_write(i2c, 0x0006, 0x0030); // CHIP_I2S_CTRL: 16-bit I2S
+
+        // ── Signal routing ──────────────────────────────────────
+        sgtl5000_write(i2c, 0x000A, 0x0010); // CHIP_SSS_CTRL: I2S→DAC
+        sgtl5000_write(i2c, 0x000E, 0x0000); // CHIP_ADCDAC_CTRL: unmute DAC
+        sgtl5000_write(i2c, 0x0010, 0x3C3C); // CHIP_DAC_VOL: 0 dB
+        sgtl5000_write(i2c, 0x0022, 0x1818); // CHIP_ANA_HP_CTRL: HP vol 0 dB
+        sgtl5000_write(i2c, 0x0020, 0x0000); // CHIP_ANA_ADC_CTRL: ADC vol 0 dB
+
+        // ── Unmute headphones ───────────────────────────────────
+        // MUTE_LO=1, SELECT_HP=0(DAC), EN_ZCD_HP=1, MUTE_HP=0,
+        // SELECT_ADC=1, EN_ZCD_ADC=1, MUTE_ADC=0
+        sgtl5000_write(i2c, 0x0024, 0x0126); // CHIP_ANA_CTRL: unmute HP
+    }
+}

--- a/src/board.rs
+++ b/src/board.rs
@@ -289,6 +289,14 @@ pub struct Resources<Pins> {
     pub trng: hal::trng::Trng,
     /// Temperature monitor of the core.
     pub tempmon: hal::tempmon::TempMon,
+    /// The register block for SAI1 (I2S audio).
+    ///
+    /// SAI1 is the primary audio interface used by the Teensy Audio Shield.
+    pub sai1: ral::sai::SAI1,
+    /// The register block for SAI2.
+    pub sai2: ral::sai::SAI2,
+    /// The register block for SAI3.
+    pub sai3: ral::sai::SAI3,
 }
 
 /// The board's dedicated LED.
@@ -374,20 +382,18 @@ pub type Lpi2c3 = hal::lpi2c::Lpi2c<hal::lpi2c::Pins<pins::common::P16, pins::co
 /// - SDO:  GPIO_SD_B0_02 (p43) or GPIO_EMC_28 (p50)
 /// - SDI:  GPIO_SD_B0_03 (p42) or GPIO_EMC_29 (p54)
 /// - SCK:  GPIO_SD_B0_00 (p45) or GPIO_EMC_27 (p49)
-/// - PCS0: GPIO_SD_B0_01 (p44) or GPIO_EMC_30
 ///
 /// Use [`lpspi`] to create this driver.
-pub type Lpspi1<SDO, SDI, SCK, PCS0> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK, PCS0>, 1>;
+pub type Lpspi1<SDO, SDI, SCK> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK>, 1>;
 
 /// LPSPI2 peripheral.
 ///
 /// - SDO:  GPIO_SD_B1_08 or GPIO_EMC_02
 /// - SDI:  GPIO_SD_B1_09 or GPIO_EMC_03
 /// - SCK:  GPIO_SD_B1_07 or GPIO_EMC_00
-/// - PCS0: GPIO_SD_B1_06 or GPIO_EMC_01
 ///
 /// Use [`lpspi`] to create this driver.
-pub type Lpspi2<SDO, SDI, SCK, PCS0> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK, PCS0>, 2>;
+pub type Lpspi2<SDO, SDI, SCK> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK>, 2>;
 
 /// LPSPI3 peripheral.
 ///
@@ -396,11 +402,10 @@ pub type Lpspi2<SDO, SDI, SCK, PCS0> = hal::lpspi::Lpspi<LpspiPins<SDO, SDI, SCK
 /// - Pin 26 is data out (SDO).
 /// - Pin 39 or 1 is data in (SDI).
 /// - Pin 27 is clock (SCK).
-/// - Pin 0 or 38 is chip select (CS).
 ///
 /// Use [`lpspi`] to create this driver.
-pub type Lpspi3<SDI, CS> =
-    hal::lpspi::Lpspi<LpspiPins<pins::common::P26, SDI, pins::common::P27, CS>, 3>;
+pub type Lpspi3<SDI> =
+    hal::lpspi::Lpspi<LpspiPins<pins::common::P26, SDI, pins::common::P27>, 3>;
 
 /// LPSPI4 peripheral.
 ///
@@ -411,7 +416,7 @@ pub type Lpspi3<SDI, CS> =
 ///
 /// Use [`lpspi`] to create this driver.
 pub type Lpspi4 = hal::lpspi::Lpspi<
-    LpspiPins<pins::common::P11, pins::common::P12, pins::common::P13, pins::common::P10>,
+    LpspiPins<pins::common::P11, pins::common::P12, pins::common::P13>,
     4,
 >;
 
@@ -435,16 +440,15 @@ pub type Lpspi4 = hal::lpspi::Lpspi<
 ///         sdo: pins.p11,
 ///         sdi: pins.p12,
 ///         sck: pins.p13,
-///         pcs0: pins.p10,
 ///     },
 ///     1_000_000,
 /// );
 /// ```
-pub fn lpspi<Sdo, Sdi, Sck, Pcs0, const N: u8>(
+pub fn lpspi<Sdo, Sdi, Sck, const N: u8>(
     instance: ral::lpspi::Instance<N>,
-    pins: LpspiPins<Sdo, Sdi, Sck, Pcs0>,
+    pins: LpspiPins<Sdo, Sdi, Sck>,
     baud: u32,
-) -> hal::lpspi::Lpspi<LpspiPins<Sdo, Sdi, Sck, Pcs0>, N>
+) -> hal::lpspi::Lpspi<LpspiPins<Sdo, Sdi, Sck>, N>
 where
     Sdo: hal::iomuxc::lpspi::Pin<
         Signal = hal::iomuxc::lpspi::Sdo,
@@ -456,10 +460,6 @@ where
     >,
     Sck: hal::iomuxc::lpspi::Pin<
         Signal = hal::iomuxc::lpspi::Sck,
-        Module = hal::iomuxc::consts::Const<N>,
-    >,
-    Pcs0: hal::iomuxc::lpspi::Pin<
-        Signal = hal::iomuxc::lpspi::Pcs0,
         Module = hal::iomuxc::consts::Const<N>,
     >,
 {
@@ -675,6 +675,9 @@ fn prepare_resources<Pins>(
         adc2,
         trng,
         tempmon,
+        sai1: instances.SAI1,
+        sai2: instances.SAI2,
+        sai3: instances.SAI3,
     }
 }
 

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -173,6 +173,59 @@ fn setup_lpspi_clk(ccm: &mut ral::ccm::CCM) {
     ccm::lpspi_clk::set_divider(ccm, LPSPI_DIVIDER);
 }
 
+// --- Audio PLL (PLL4) and SAI clock configuration ---
+//
+// The Audio PLL is configured to produce a MCLK that yields a ~44117.647 Hz sample rate.
+// This mirrors the Teensy Audio Library's C++ `set_audioClock(28, 2348, 10000)`:
+//
+//   PLL4 = 24 MHz × (28 + 2348/10000) / 1 = 677,635,200 Hz
+//   SAI1_CLK = PLL4 / prediv(4) / podf(15) = 11,293,920 Hz (MCLK)
+//   Sample rate = MCLK / 256 ≈ 44,117.656 Hz
+//
+
+/// Audio PLL (PLL4) divider selection.
+const AUDIO_PLL_DIV_SELECT: u32 = 28;
+/// Audio PLL numerator.
+const AUDIO_PLL_NUM: u32 = 2348;
+/// Audio PLL denominator.
+const AUDIO_PLL_DENOM: u32 = 10000;
+
+/// SAI clock predivider (1..=8).
+const SAI_CLK_PREDIVIDER: u32 = 4;
+/// SAI clock post-divider (1..=64).
+const SAI_CLK_DIVIDER: u32 = 15;
+
+/// Frequency (Hz) of the SAI MCLK after all dividers.
+///
+/// Approximately 11,293,920 Hz, yielding ~44,117.656 Hz sample rate
+/// when MCLK/BCLK ratio is 256.
+pub const SAI_MCLK_FREQUENCY: u32 = {
+    // PLL4 output frequency (with post_div = 1):
+    // 24_000_000 * (28 + 2348/10000) = 24_000_000 * 28 + 24_000_000 * 2348 / 10000
+    let pll4_freq: u32 =
+        XTAL_OSCILLATOR_HZ * AUDIO_PLL_DIV_SELECT + XTAL_OSCILLATOR_HZ / AUDIO_PLL_DENOM * AUDIO_PLL_NUM;
+    pll4_freq / SAI_CLK_PREDIVIDER / SAI_CLK_DIVIDER
+};
+
+/// Configure the Audio PLL (PLL4) for 44.1 kHz–family sample rates.
+fn setup_audio_pll(ccm_analog: &mut ral::ccm_analog::CCM_ANALOG) {
+    ccm::analog::pll4::reconfigure(
+        ccm_analog,
+        AUDIO_PLL_DIV_SELECT,
+        AUDIO_PLL_NUM,
+        AUDIO_PLL_DENOM,
+        ccm::analog::pll4::PostDivider::U1,
+    );
+}
+
+/// Configure SAI1 clock root to derive from Audio PLL.
+fn setup_sai1_clk(ccm: &mut ral::ccm::CCM) {
+    clock_gate::sai::<1>().set(ccm, clock_gate::OFF);
+    ccm::sai_clk::set_selection::<1>(ccm, ccm::sai_clk::Selection::Pll4);
+    ccm::sai_clk::set_predivider::<1>(ccm, SAI_CLK_PREDIVIDER);
+    ccm::sai_clk::set_divider::<1>(ccm, SAI_CLK_DIVIDER);
+}
+
 const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::pit(),
     clock_gate::gpt_bus::<1>(),
@@ -211,6 +264,9 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::adc::<1>(),
     clock_gate::adc::<2>(),
     clock_gate::trng(),
+    clock_gate::sai::<1>(),
+    clock_gate::sai::<2>(),
+    clock_gate::sai::<3>(),
 ];
 
 /// Prepare clocks and power for the MCU.
@@ -231,6 +287,8 @@ pub fn prepare_clocks_and_power(
     setup_lpspi_clk(ccm);
     setup_perclk_clk(ccm);
     setup_uart_clk(ccm);
+    setup_audio_pll(ccm_analog);
+    setup_sai1_clk(ccm);
 
     CLOCK_GATES
         .iter()


### PR DESCRIPTION
Enable SAI1-3 clock gates, configure Audio PLL (PLL4) for 44.1 kHz sample rates, expose SAI peripherals in the BSP, and add two working audio examples for the Teensy 4.1 + Audio Shield Rev D (SGTL5000):

- rtic_sai_poll_tone: interrupt-driven FIFO polling (no DMA)
- rtic_sai_dma_tone: DMA-driven I2S transfers

Also updates dependencies to imxrt-hal v0.6 / imxrt-ral v0.6 and fixes LPSPI PCS0 removal and usb-device v0.3 API changes.