### PR TITLE
Add SAI clock gates, Audio PLL config, and SAI resources in BSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 /out
 /svd/imxrt1062/*
 .vscode/
+.claude/
 
 # Let developers specify their own configs in non Teensy crates
 imxrt1062-fcb-gen/.cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Add LPUART5 and LPUART7 aliases, resources, to teensy4-bsp.
 
+Add SAI clock gates, Audio PLL config, and SAI resources in BSP.
+The BSP configures the SAI1 root clock, but doesn't affect SAI2
+or SAI3 root clocks.
+
+Expose the IOMUXC_GPR through resources.
+
 ## [0.5.1] 2024-11-11
 
 Add additional LPSPI instances and type aliases.

--- a/examples/rtic_defmt_usb_log.rs
+++ b/examples/rtic_defmt_usb_log.rs
@@ -179,19 +179,19 @@ mod app {
             defmt::println!("Hello from defmt! The count is {=u32}", counter);
             defmt::trace!("TRACE: {=u32}", counter);
 
-            if counter % 3 == 0 {
+            if counter.is_multiple_of(3) {
                 defmt::debug!("DEBUG: {=u32}", counter);
             }
 
-            if counter % 5 == 0 {
+            if counter.is_multiple_of(5) {
                 defmt::info!("INFO: {=u32}", counter);
             }
 
-            if counter % 7 == 0 {
+            if counter.is_multiple_of(7) {
                 defmt::warn!("WARN: {=u32}", counter);
             }
 
-            if counter % 31 == 0 {
+            if counter.is_multiple_of(31) {
                 defmt::error!("ERROR: {=u32}", counter);
             }
 

--- a/examples/rtic_usb_log.rs
+++ b/examples/rtic_usb_log.rs
@@ -90,19 +90,19 @@ mod app {
 
             log::trace!("TRACE: {counter}");
 
-            if counter % 3 == 0 {
+            if counter.is_multiple_of(3) {
                 log::debug!("DEBUG: {counter}");
             }
 
-            if counter % 5 == 0 {
+            if counter.is_multiple_of(5) {
                 log::info!("INFO: {counter}");
             }
 
-            if counter % 7 == 0 {
+            if counter.is_multiple_of(7) {
                 log::warn!("WARN: {counter}");
             }
 
-            if counter % 31 == 0 {
+            if counter.is_multiple_of(31) {
                 log::error!("ERROR: {counter}");
             }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -289,6 +289,16 @@ pub struct Resources<Pins> {
     pub trng: hal::trng::Trng,
     /// Temperature monitor of the core.
     pub tempmon: hal::tempmon::TempMon,
+    /// The register block for SAI1 (I2S audio).
+    ///
+    /// SAI1 is the primary audio interface used by the Teensy Audio Shield.
+    pub sai1: ral::sai::SAI1,
+    /// The register block for SAI2.
+    pub sai2: ral::sai::SAI2,
+    /// The register block for SAI3.
+    pub sai3: ral::sai::SAI3,
+    /// The IOMUXC general purpose register block.
+    pub iomuxc_gpr: ral::iomuxc_gpr::IOMUXC_GPR,
 }
 
 /// The board's dedicated LED.
@@ -675,6 +685,10 @@ fn prepare_resources<Pins>(
         adc2,
         trng,
         tempmon,
+        sai1: instances.SAI1,
+        sai2: instances.SAI2,
+        sai3: instances.SAI3,
+        iomuxc_gpr: instances.IOMUXC_GPR,
     }
 }
 

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -173,6 +173,59 @@ fn setup_lpspi_clk(ccm: &mut ral::ccm::CCM) {
     ccm::lpspi_clk::set_divider(ccm, LPSPI_DIVIDER);
 }
 
+// --- Audio PLL (PLL4) and SAI clock configuration ---
+//
+// The Audio PLL is configured to produce a MCLK that yields a ~44117.647 Hz sample rate.
+// This mirrors the Teensy Audio Library's C++ `set_audioClock(28, 2348, 10000)`:
+//
+//   PLL4 = 24 MHz × (28 + 2348/10000) / 1 = 677,635,200 Hz
+//   SAI1_CLK = PLL4 / prediv(4) / podf(15) = 11,293,920 Hz (MCLK)
+//   Sample rate = MCLK / 256 ≈ 44,117.656 Hz
+//
+
+/// Audio PLL (PLL4) divider selection.
+const AUDIO_PLL_DIV_SELECT: u32 = 28;
+/// Audio PLL numerator.
+const AUDIO_PLL_NUM: u32 = 2348;
+/// Audio PLL denominator.
+const AUDIO_PLL_DENOM: u32 = 10000;
+
+/// SAI clock predivider (1..=8).
+const SAI_CLK_PREDIVIDER: u32 = 4;
+/// SAI clock post-divider (1..=64).
+const SAI_CLK_DIVIDER: u32 = 15;
+
+/// Frequency (Hz) of the SAI1 MCLK after all dividers.
+///
+/// Approximately 11,293,920 Hz, yielding ~44,117.656 Hz sample rate
+/// when MCLK/BCLK ratio is 256.
+pub const SAI1_FREQUENCY: u32 = {
+    // PLL4 output frequency (with post_div = 1):
+    // 24_000_000 * (28 + 2348/10000) = 24_000_000 * 28 + 24_000_000 * 2348 / 10000
+    let pll4_freq: u32 = XTAL_OSCILLATOR_HZ * AUDIO_PLL_DIV_SELECT
+        + XTAL_OSCILLATOR_HZ / AUDIO_PLL_DENOM * AUDIO_PLL_NUM;
+    pll4_freq / SAI_CLK_PREDIVIDER / SAI_CLK_DIVIDER
+};
+
+/// Configure the Audio PLL (PLL4) for 44.1 kHz–family sample rates.
+fn setup_audio_pll(ccm_analog: &mut ral::ccm_analog::CCM_ANALOG) {
+    ccm::analog::pll4::reconfigure(
+        ccm_analog,
+        AUDIO_PLL_DIV_SELECT,
+        AUDIO_PLL_NUM,
+        AUDIO_PLL_DENOM,
+        ccm::analog::pll4::PostDivider::U1,
+    );
+}
+
+/// Configure SAI1 clock root to derive from Audio PLL.
+fn setup_sai1_clk(ccm: &mut ral::ccm::CCM) {
+    clock_gate::sai::<1>().set(ccm, clock_gate::OFF);
+    ccm::sai_clk::set_selection::<1>(ccm, ccm::sai_clk::Selection::Pll4);
+    ccm::sai_clk::set_predivider::<1>(ccm, SAI_CLK_PREDIVIDER);
+    ccm::sai_clk::set_divider::<1>(ccm, SAI_CLK_DIVIDER);
+}
+
 const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::pit(),
     clock_gate::gpt_bus::<1>(),
@@ -211,6 +264,9 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::adc::<1>(),
     clock_gate::adc::<2>(),
     clock_gate::trng(),
+    clock_gate::sai::<1>(),
+    clock_gate::sai::<2>(),
+    clock_gate::sai::<3>(),
 ];
 
 /// Prepare clocks and power for the MCU.
@@ -231,6 +287,8 @@ pub fn prepare_clocks_and_power(
     setup_lpspi_clk(ccm);
     setup_perclk_clk(ccm);
     setup_uart_clk(ccm);
+    setup_audio_pll(ccm_analog);
+    setup_sai1_clk(ccm);
 
     CLOCK_GATES
         .iter()


### PR DESCRIPTION
Enable SAI1-3 clock gates, configure Audio PLL (PLL4) for 44.1 kHz sample rates, and expose sai1/sai2/sai3 register blocks in board Resources. Addresses issue #182.