### PR TITLE
Usdhc1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Add USDHC1 clock configuration and expose the USDHC1 peripheral instance in
+board resources. The BSP configures the USDHC1 root clock and publishes the
+frequency as `USDHC1_FREQUENCY`. Pin muxing and driver initialization are left
+to the caller.
+
 ### [0.5.2] 2026-03-10
 
 Add LPUART5 and LPUART7 aliases, resources, to teensy4-bsp.

--- a/src/board.rs
+++ b/src/board.rs
@@ -299,6 +299,8 @@ pub struct Resources<Pins> {
     pub sai3: ral::sai::SAI3,
     /// The IOMUXC general purpose register block.
     pub iomuxc_gpr: ral::iomuxc_gpr::IOMUXC_GPR,
+    /// The USDHC1 peripheral instance.
+    pub usdhc1: ral::usdhc::USDHC1,
 }
 
 /// The board's dedicated LED.
@@ -689,6 +691,7 @@ fn prepare_resources<Pins>(
         sai2: instances.SAI2,
         sai3: instances.SAI3,
         iomuxc_gpr: instances.IOMUXC_GPR,
+        usdhc1: instances.USDHC1,
     }
 }
 

--- a/src/clock_power.rs
+++ b/src/clock_power.rs
@@ -267,6 +267,7 @@ const CLOCK_GATES: &[clock_gate::Locator] = &[
     clock_gate::sai::<1>(),
     clock_gate::sai::<2>(),
     clock_gate::sai::<3>(),
+    clock_gate::usdhc::<1>(),
 ];
 
 /// Prepare clocks and power for the MCU.
@@ -289,8 +290,29 @@ pub fn prepare_clocks_and_power(
     setup_uart_clk(ccm);
     setup_audio_pll(ccm_analog);
     setup_sai1_clk(ccm);
+    setup_usdhc1_clk(ccm);
 
     CLOCK_GATES
         .iter()
         .for_each(|locator| locator.set(ccm, clock_gate::ON));
+}
+
+/// USDHC1 root clock frequency (Hz).
+///
+/// PLL2_PFD2 (396 MHz) / 2 = 198 MHz. The actual SD bus clock is
+/// further divided by the USDHC1 peripheral's internal SDCLKFS and
+/// DVS dividers during card initialization.
+pub const USDHC1_FREQUENCY: u32 = 198_000_000;
+
+/// Configure the USDHC1 clock root for the SD card slot.
+///
+/// Source: PLL2_PFD2 (396 MHz), divider: /2 → 198 MHz root clock.
+///
+/// PLL2 (528 MHz) and its PFD2 output (396 MHz) are initialized by the
+/// Teensy bootloader before transferring control to user code. This
+/// function assumes PLL2_PFD2 is already running and stable.
+fn setup_usdhc1_clk(ccm: &mut ral::ccm::CCM) {
+    clock_gate::usdhc::<1>().set(ccm, clock_gate::OFF);
+    ral::modify_reg!(ral::ccm, ccm, CSCMR1, USDHC1_CLK_SEL: 0); // PLL2_PFD2
+    ral::modify_reg!(ral::ccm, ccm, CSCDR1, USDHC1_PODF: 1); // divide by 2
 }


### PR DESCRIPTION
Integrate the imxrt-usdhc driver crate into the BSP:
- Configure USDHC1 root clock (PLL2_PFD2 / 2 = 198 MHz)
- Add USDHC1 instance to board Resources
- Add usdhc1 module with pin config and init_usdhc1() convenience fn
- Re-export embedded_sdmmc, Usdhc, SdPins, etc. from board module
- Add rtic_sd_info example (card init + FAT32 root dir listing)